### PR TITLE
[CLI] Add basic CLI 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+[BASIC]
+good-names=
+    i,
+    e,

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -5,18 +5,22 @@ from browser_history import generic, browsers, utils
 # get list of all implemented browser by finding subclasses of generic.Browser
 available_browsers = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
 
-parser = argparse.ArgumentParser(description='''
-                                    A tool to retrieve history from
-                                    (almost) any browser on (almost) any platform''',
-                                 epilog='''
-                                    Checkout the GitHub repo https://github.com/pesos/browser-history
-                                    if you have any issues or want to help contribute''')
+def make_parser():
+    cli_parser = argparse.ArgumentParser(description='''
+                                            A tool to retrieve history from
+                                            (almost) any browser on (almost) any platform''',
+                                         epilog='''
+                                            Checkout the GitHub repo https://github.com/pesos/browser-history
+                                            if you have any issues or want to help contribute''')
 
-parser.add_argument('-b', '--browser',
-                    default='all',
-                    help=f'''
-                        browser to retrieve history from. Should be one of all, {available_browsers}.
-                        Default is all (gets history from all browsers).''')
+    cli_parser.add_argument('-b', '--browser',
+                            default='all',
+                            help=f'''
+                                browser to retrieve history from. Should be one of all, {available_browsers}.
+                                Default is all (gets history from all browsers).''')
+    return cli_parser
+
+parser = make_parser()
 
 def main():
     args = parser.parse_args()

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -2,18 +2,21 @@ import sys
 import argparse
 from browser_history import generic, browsers, utils
 
+# get list of all implemented browser by finding subclasses of generic.Browser
 available_browsers = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
-parser = argparse.ArgumentParser(description='''A tool to retrieve history from
-                                             (almost) any browser on (almost) any platform''',
+
+parser = argparse.ArgumentParser(description='''
+                                    A tool to retrieve history from
+                                    (almost) any browser on (almost) any platform''',
                                  epilog='''
                                     Checkout the GitHub repo https://github.com/pesos/browser-history
                                     if you have any issues or want to help contribute''')
+
 parser.add_argument('-b', '--browser',
                     default='all',
                     help=f'''
                         browser to retrieve history from. Should be one of all, {available_browsers}.
-                        Default is all (gets history from all browsers).
-                    ''')
+                        Default is all (gets history from all browsers).''')
 
 def main():
     args = parser.parse_args()
@@ -23,6 +26,7 @@ def main():
 
     else:
         try:
+            # gets browser class by name (string). TODO: make it case-insensitive
             browser_class = getattr(browsers, args.browser)
         except AttributeError:
             print(f'Browser {args.browser} is unavailable. Check --help for available browsers')
@@ -36,4 +40,5 @@ def main():
             sys.exit(1)
 
     for date, url in outputs.get():
+        # comma-separated output. NOT a CSV file
         print(f'{date},{url}')

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -1,0 +1,44 @@
+import sys
+import argparse
+from browser_history import generic, browsers
+
+available_browsers = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
+parser = argparse.ArgumentParser(description='''A tool to retrieve history from
+                                             (almost) any browser on (almost) any platform''',
+                                 epilog='''
+                                    Checkout the GitHub repo https://github.com/pesos/browser-history
+                                    if you have any issues or want to help contribute''')
+parser.add_argument('-b', '--browser',
+                    default='all',
+                    help=f'''
+                        browser to retrieve history from. Should be one of all, {available_browsers}.
+                        Default is all (gets history from all browsers).
+                    ''')
+
+def main():
+    if len(sys.argv) <= 1:
+        parser.print_help()
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    if args.browser == 'all':
+        # TODO: fix after #15 is merged
+        raise NotImplementedError('Browser "all" is not available yet')
+
+    else:
+        try:
+            browser_class = getattr(browsers, args.browser)
+        except AttributeError:
+            print(f'Browser {args.browser} is unavailable. Check --help for available browsers')
+            sys.exit(1)
+
+        try:
+            browser = browser_class().fetch()
+            outputs = browser
+        except AssertionError as e:
+            print(e)
+            sys.exit(1)
+
+        for date, url in outputs.get():
+            print(f'{date},{url}')

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -1,11 +1,20 @@
+"""This module defines functions and globals required for the
+command line interface of browser-history."""
+
 import sys
 import argparse
 from browser_history import generic, browsers, utils
 
 # get list of all implemented browser by finding subclasses of generic.Browser
-available_browsers = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
+AVAILABLE_BROWSERS = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
 
 def make_parser():
+    """Creates an ArgumentParser, configures and returns it.
+
+    This was made into a separate function to be used with sphinx-argparse
+
+    :rtype: :py:class:`argparse.ArgumentParser`
+    """
     cli_parser = argparse.ArgumentParser(description='''
                                             A tool to retrieve history from
                                             (almost) any browser on (almost) any platform''',
@@ -16,13 +25,17 @@ def make_parser():
     cli_parser.add_argument('-b', '--browser',
                             default='all',
                             help=f'''
-                                browser to retrieve history from. Should be one of all, {available_browsers}.
+                                browser to retrieve history from. Should be one of all, {AVAILABLE_BROWSERS}.
                                 Default is all (gets history from all browsers).''')
     return cli_parser
 
 parser = make_parser()
 
 def main():
+    """Entrypoint to the command-line interface (CLI) of browser-history.
+
+    It parses arguments from sys.argv and performs the appropriate actions.
+    """
     args = parser.parse_args()
 
     if args.browser == 'all':

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -15,19 +15,19 @@ def make_parser():
 
     :rtype: :py:class:`argparse.ArgumentParser`
     """
-    cli_parser = argparse.ArgumentParser(description='''
+    parser_ = argparse.ArgumentParser(description='''
                                             A tool to retrieve history from
                                             (almost) any browser on (almost) any platform''',
                                          epilog='''
                                             Checkout the GitHub repo https://github.com/pesos/browser-history
                                             if you have any issues or want to help contribute''')
 
-    cli_parser.add_argument('-b', '--browser',
+    parser_.add_argument('-b', '--browser',
                             default='all',
                             help=f'''
                                 browser to retrieve history from. Should be one of all, {AVAILABLE_BROWSERS}.
                                 Default is all (gets history from all browsers).''')
-    return cli_parser
+    return parser_
 
 parser = make_parser()
 

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -1,6 +1,6 @@
 import sys
 import argparse
-from browser_history import generic, browsers
+from browser_history import generic, browsers, utils
 
 available_browsers = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
 parser = argparse.ArgumentParser(description='''A tool to retrieve history from
@@ -16,15 +16,10 @@ parser.add_argument('-b', '--browser',
                     ''')
 
 def main():
-    if len(sys.argv) <= 1:
-        parser.print_help()
-        sys.exit(1)
-
     args = parser.parse_args()
 
     if args.browser == 'all':
-        # TODO: fix after #15 is merged
-        raise NotImplementedError('Browser "all" is not available yet')
+        outputs = utils.get_history()
 
     else:
         try:
@@ -40,5 +35,5 @@ def main():
             print(e)
             sys.exit(1)
 
-        for date, url in outputs.get():
-            print(f'{date},{url}')
+    for date, url in outputs.get():
+        print(f'{date},{url}')

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,18 @@
+.. _cli:
+
+Command Line Interface
+======================
+
+This package provides a command line tool named ``browser-history`` that is
+automatically added to path when installed through ``pip``.
+
+Help page for the CLI is given below. It can also be accessed using
+``browser-history --help``.
+
+CLI Help Page
+-------------
+
+.. argparse::
+   :module: browser_history.cli
+   :func: make_parser
+   :prog: browser-history

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ release = '0.1.1'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx_rtd_theme'
+    'sphinx_rtd_theme',
+    'sphinxarg.ext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ or platform, please open an issue on `the GitHub Page <https://github.com/pesos/
    :caption: Contents:
 
    quickstart
+   cli
    browsers
    API
    contributing

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,11 +3,17 @@
 Quick Start
 ===========
 
-Installation::
+Installation
+------------
+
+::
 
     pip install browser-history
 
-Get started::
+Get started
+-----------
+
+::
 
     from browser_history.browsers import Firefox
 
@@ -18,4 +24,14 @@ Get started::
 - ``Firefox`` in the above snippet can be replaced with any of the :ref:`supported_browsers`.
 - ``his`` is a list of ``(datetime.datetime, url)`` tuples.
 
+Command Line
+------------
 
+Running ``browser-history`` in shell/terminal/command prompt will return history from all
+browsers with each line in the output containing the timestamp and URL separated by a comma.
+
+To get history from a specific browser::
+
+    browser-history -b Firefox
+
+Checkout the :ref:`cli` help page for more information

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
 Sphinx==3.1.2
+sphinx-argparse==0.2.5
+sphinx-rtd-theme==0.5.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-sphinx-rtd-theme==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    entry_points = {
+        'console_scripts': ['browser-history=browser_history.cli:main'],
+    }
 )


### PR DESCRIPTION
# Description

- This CLI has only two arguments - help and browser. Waiting for #15 to be merged before adding the 'all' option for browser choice.
- CLI is added to path in setup.py, allowing it to be called using `browser-history`.
- Usage: `browser-history -h`
- No documentation yet.

Fixes #5 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
