### PR TITLE
[DOC] Demonstrate get_history() & fix grammar mistakes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+[BASIC]
+good-names=
+    i,
+    e,

--- a/README.md
+++ b/README.md
@@ -18,20 +18,24 @@ package to retrieve (almost) any browser's history on (almost) any platform.
 
 ```python
 from browser_history.browsers import Firefox
-from browser_history.utils import *
 
 f = Firefox.fetch()
 
 his = f.get()
-
-all_browsers = get_history()
-
-all_histories = all_browsers.get()
 ```
-
  - `Firefox` in the above snippet can be replaced with any of the [supported browsers](https://browser-history.readthedocs.io/en/latest/browsers.html).
  - `his` is a list of `(datetime.datetime, url)` tuples from the firefox browser.
- - ``all_histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
+
+
+```python
+from browser_history.utils import get_history
+
+outputs = get_history()
+
+histories = outputs.get()
+```
+
+ - ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
 
 Check out the [documentation](https://browser-history.readthedocs.io/en/latest/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@ package to retrieve (almost) any browser's history on (almost) any platform.
 
 ```python
 from browser_history.browsers import Firefox
+from browser_history.utils import *
 
 f = Firefox.fetch()
 
 his = f.get()
+
+all_browsers = get_history()
+
+all_histories = all_browsers.get()
 ```
 
  - `Firefox` in the above snippet can be replaced with any of the [supported browsers](https://browser-history.readthedocs.io/en/latest/browsers.html).
- - `his` is a list of `(datetime.datetime, url)` tuples.
+ - `his` is a list of `(datetime.datetime, url)` tuples from the firefox browser.
+ - ``all_histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
 
 Check out the [documentation](https://browser-history.readthedocs.io/en/latest/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ package to retrieve (almost) any browser's history on (almost) any platform.
 
 ## Usage
 
+To get history from all installed browsers:
+```python
+from browser_history.utils import get_history
+
+outputs = get_history()
+
+histories = outputs.get()
+```
+
+ - ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
+
+If you want history from a specific browser:
 ```python
 from browser_history.browsers import Firefox
 
@@ -26,16 +38,6 @@ his = f.get()
  - `Firefox` in the above snippet can be replaced with any of the [supported browsers](https://browser-history.readthedocs.io/en/latest/browsers.html).
  - `his` is a list of `(datetime.datetime, url)` tuples from the firefox browser.
 
-
-```python
-from browser_history.utils import get_history
-
-outputs = get_history()
-
-histories = outputs.get()
-```
-
- - ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
 
 Check out the [documentation](https://browser-history.readthedocs.io/en/latest/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ his = f.get()
  - `Firefox` in the above snippet can be replaced with any of the [supported browsers](https://browser-history.readthedocs.io/en/latest/browsers.html).
  - `his` is a list of `(datetime.datetime, url)` tuples from the firefox browser.
 
+<<<<<<< HEAD
+=======
+
+```python
+from browser_history.utils import get_history
+
+outputs = get_history()
+
+histories = outputs.get()
+```
+
+ - ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
+>>>>>>> a18905f7a05b23ac3f1bf34369968b51debd585e
 
 Check out the [documentation](https://browser-history.readthedocs.io/en/latest/) for more details.
 

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -32,7 +32,7 @@ class Chrome(Browser):
         WHERE urls.id = visits.url ORDER BY visit_time DESC"""
 
 class Chromium(Browser):
-    """Google Chrome Browser
+    """Chromium Browser
 
     Supported platforms (TODO: Windows and Mac OS support)
 

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -1,0 +1,61 @@
+"""This module defines functions and globals required for the
+command line interface of browser-history."""
+
+import sys
+import argparse
+from browser_history import generic, browsers, utils
+
+# get list of all implemented browser by finding subclasses of generic.Browser
+AVAILABLE_BROWSERS = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
+
+def make_parser():
+    """Creates an ArgumentParser, configures and returns it.
+
+    This was made into a separate function to be used with sphinx-argparse
+
+    :rtype: :py:class:`argparse.ArgumentParser`
+    """
+    parser_ = argparse.ArgumentParser(description='''
+                                            A tool to retrieve history from
+                                            (almost) any browser on (almost) any platform''',
+                                         epilog='''
+                                            Checkout the GitHub repo https://github.com/pesos/browser-history
+                                            if you have any issues or want to help contribute''')
+
+    parser_.add_argument('-b', '--browser',
+                            default='all',
+                            help=f'''
+                                browser to retrieve history from. Should be one of all, {AVAILABLE_BROWSERS}.
+                                Default is all (gets history from all browsers).''')
+    return parser_
+
+parser = make_parser()
+
+def main():
+    """Entrypoint to the command-line interface (CLI) of browser-history.
+
+    It parses arguments from sys.argv and performs the appropriate actions.
+    """
+    args = parser.parse_args()
+
+    if args.browser == 'all':
+        outputs = utils.get_history()
+
+    else:
+        try:
+            # gets browser class by name (string). TODO: make it case-insensitive
+            browser_class = getattr(browsers, args.browser)
+        except AttributeError:
+            print(f'Browser {args.browser} is unavailable. Check --help for available browsers')
+            sys.exit(1)
+
+        try:
+            browser = browser_class().fetch()
+            outputs = browser
+        except AssertionError as e:
+            print(e)
+            sys.exit(1)
+
+    for date, url in outputs.get():
+        # comma-separated output. NOT a CSV file
+        print(f'{date},{url}')

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -52,8 +52,8 @@ def get_history():
     browsers for the system platform.
 
     :return: Object of class :py:class:`browser_history.generic.Outputs` with the
-    data member entries set to list(tuple(:py:class:`datetime.datetime`, str))
-    
+        data member entries set to list(tuple(:py:class:`datetime.datetime`, str))
+
     :rtype: :py:class:`browser_history.generic.Outputs`
     """
     output_object = generic.Outputs()
@@ -64,7 +64,7 @@ def get_history():
             browser_output_object = browser_object.fetch()
             output_object.entries.extend(browser_output_object.get())
         except AssertionError:
-            logger.info("%s browser is not supported", browser_class.name)    
+            logger.info("%s browser is not supported", browser_class.name)
     output_object.entries.sort()
     return output_object
     

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,18 @@
+.. _cli:
+
+Command Line Interface
+======================
+
+This package provides a command line tool named ``browser-history`` that is
+automatically added to path when installed through ``pip``.
+
+Help page for the CLI is given below. It can also be accessed using
+``browser-history --help``.
+
+CLI Help Page
+-------------
+
+.. argparse::
+   :module: browser_history.cli
+   :func: make_parser
+   :prog: browser-history

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ release = '0.1.1'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx_rtd_theme'
+    'sphinx_rtd_theme',
+    'sphinxarg.ext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,11 @@ Development Process - Short Version
 #. Work on the master branch for smaller patches and a separate branch for new features.
 #. Make changes, ``git add`` and then commit. Make sure to link the issue number in the commit message.
 #. Run the following commands: ``pylint browser_history``, ``pytest --cov=./browser_history``
+<<<<<<< HEAD
 #. (Optional) If you're updating the documentation, Update ``docs/quickstart.rst`` and ``README.md`` simultaneously.
+=======
+#. (Optional) If you're updating the documentation, Update ``docs/quickstart.rst`` and ``README.md`` simoultaneously.
+>>>>>>> a18905f7a05b23ac3f1bf34369968b51debd585e
    Run the following: ``cd docs``, ``make html`` and then open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.
 #. If all tests are passing, pull changes from the original remote with a rebase, and push the changes to your remote repository.
 #. Use the GitHub website to create a Pull Request and wait for the maintainers to review it.
@@ -79,7 +83,11 @@ Development Process - Long Version
 
 #. (Optional) If you're updating the documentation, run the following:
 
+<<<<<<< HEAD
    .. caution:: If you're updating ``docs/quickstart.rst`` simultaneously update ``README.md``.
+=======
+   .. caution:: If you're updating ``docs/quickstart.rst`` simoultaneously update ``README.md``.
+>>>>>>> a18905f7a05b23ac3f1bf34369968b51debd585e
    
    * Change to the docs directory: ``cd docs``
    * Build the documentation: ``make html``

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,7 @@ Development Process - Short Version
 #. Work on the master branch for smaller patches and a separate branch for new features.
 #. Make changes, ``git add`` and then commit. Make sure to link the issue number in the commit message.
 #. Run the following commands: ``pylint browser_history``, ``pytest --cov=./browser_history``
-#. (Optional) If you're updating the documentation, Update ``docs/quickstart.rst`` and ``README.md`` simoultaneously.
+#. (Optional) If you're updating the documentation, Update ``docs/quickstart.rst`` and ``README.md`` simultaneously.
    Run the following: ``cd docs``, ``make html`` and then open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.
 #. If all tests are passing, pull changes from the original remote with a rebase, and push the changes to your remote repository.
 #. Use the GitHub website to create a Pull Request and wait for the maintainers to review it.
@@ -79,7 +79,7 @@ Development Process - Long Version
 
 #. (Optional) If you're updating the documentation, run the following:
 
-   .. caution:: If you're updating ``docs/quickstart.rst`` simoultaneously update ``README.md``.
+   .. caution:: If you're updating ``docs/quickstart.rst`` simultaneously update ``README.md``.
    
    * Change to the docs directory: ``cd docs``
    * Build the documentation: ``make html``

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,8 +24,8 @@ Development Process - Short Version
 #. Work on the master branch for smaller patches and a separate branch for new features.
 #. Make changes, ``git add`` and then commit. Make sure to link the issue number in the commit message.
 #. Run the following commands: ``pylint browser_history``, ``pytest --cov=./browser_history``
-#. (Optional) If you're updating the documentation, run the following: ``cd docs``, ``make html``
-   and then open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.
+#. (Optional) If you're updating the documentation, Update ``docs/quickstart.rst`` and ``README.md`` simoultaneously.
+   Run the following: ``cd docs``, ``make html`` and then open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.
 #. If all tests are passing, pull changes from the original remote with a rebase, and push the changes to your remote repository.
 #. Use the GitHub website to create a Pull Request and wait for the maintainers to review it.
 
@@ -79,6 +79,8 @@ Development Process - Long Version
 
 #. (Optional) If you're updating the documentation, run the following:
 
+   .. caution:: If you're updating ``docs/quickstart.rst`` simoultaneously update ``README.md``.
+   
    * Change to the docs directory: ``cd docs``
    * Build the documentation: ``make html``
    * Open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Check out the :ref:`quick_start` to get started.
 
 This project relies on contributions made by other people especially for browsers
 other than Chrome, Firefox and Safari and for platforms other than Windows, Mac
-and Linux. As such, if notice any issues or if there is no support for your browser
+and Linux. As such, if you notice any issues or if there is no support for your browser
 or platform, please open an issue on `the GitHub Page <https://github.com/pesos/browser-history>`_
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ or platform, please open an issue on `the GitHub Page <https://github.com/pesos/
    :caption: Contents:
 
    quickstart
+   cli
    browsers
    API
    contributing

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,6 +12,7 @@ Installation
 
 Get started:
 
+<<<<<<< HEAD
 To get history from all installed browsers:
 ::
 
@@ -26,6 +27,8 @@ To get history from all installed browsers:
 
 
 If you want history from a specific browser:
+=======
+>>>>>>> a18905f7a05b23ac3f1bf34369968b51debd585e
 ::
 
     from browser_history.browsers import Firefox
@@ -39,6 +42,7 @@ If you want history from a specific browser:
 
 
 
+<<<<<<< HEAD
 
 Command Line
 ------------
@@ -47,6 +51,18 @@ Running ``browser-history`` in shell/terminal/command prompt will return history
 browsers with each line in the output containing the timestamp and URL separated by a comma.
 
 To get history from a specific browser::
+=======
+::
+
+    from browser_history.utils import get_history
+
+    outputs = get_history()
+
+    histories = outputs.get()
+
+
+- ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
+>>>>>>> a18905f7a05b23ac3f1bf34369968b51debd585e
 
     browser-history -b Firefox
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,25 +10,31 @@ Installation
 
     pip install browser-history
 
-Get started
------------
+Get started:
 
 ::
 
     from browser_history.browsers import Firefox
-    from browser_history.utils import *
 
     f = Firefox.fetch()
 
     his = f.get()
 
-    all_browsers = get_history()
-
-    all_histories = all_browsers.get()
-
 - ``Firefox`` in the above snippet can be replaced with any of the :ref:`supported_browsers`.
 - ``his`` is a list of ``(datetime.datetime, url)`` tuples from the firefox browser.
-- ``all_histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
+
+
+
+::
+
+    from browser_history.utils import get_history
+
+    outputs = get_history()
+
+    histories = outputs.get()
+
+
+- ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
 
 Command Line
 ------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,11 +3,17 @@
 Quick Start
 ===========
 
-Installation::
+Installation
+------------
+
+::
 
     pip install browser-history
 
-Get started::
+Get started
+-----------
+
+::
 
     from browser_history.browsers import Firefox
 
@@ -18,4 +24,14 @@ Get started::
 - ``Firefox`` in the above snippet can be replaced with any of the :ref:`supported_browsers`.
 - ``his`` is a list of ``(datetime.datetime, url)`` tuples.
 
+Command Line
+------------
 
+Running ``browser-history`` in shell/terminal/command prompt will return history from all
+browsers with each line in the output containing the timestamp and URL separated by a comma.
+
+To get history from a specific browser::
+
+    browser-history -b Firefox
+
+Checkout the :ref:`cli` help page for more information

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,6 +12,20 @@ Installation
 
 Get started:
 
+To get history from all installed browsers:
+::
+
+    from browser_history.utils import get_history
+
+    outputs = get_history()
+
+    histories = outputs.get()
+
+
+- ``histories`` is a list of ``(datetime.datetime, url)`` tuples.
+
+
+If you want history from a specific browser:
 ::
 
     from browser_history.browsers import Firefox
@@ -25,16 +39,6 @@ Get started:
 
 
 
-::
-
-    from browser_history.utils import get_history
-
-    outputs = get_history()
-
-    histories = outputs.get()
-
-
-- ``histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
 
 Command Line
 ------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,13 +16,19 @@ Get started
 ::
 
     from browser_history.browsers import Firefox
+    from browser_history.utils import *
 
     f = Firefox.fetch()
 
-    histories = f.get()
+    his = f.get()
+
+    all_browsers = get_history()
+
+    all_histories = all_browsers.get()
 
 - ``Firefox`` in the above snippet can be replaced with any of the :ref:`supported_browsers`.
-- ``his`` is a list of ``(datetime.datetime, url)`` tuples.
+- ``his`` is a list of ``(datetime.datetime, url)`` tuples from the firefox browser.
+- ``all_histories`` is a list of ``(datetime.datetime, url)`` tuples from every browser installed on the system.
 
 Command Line
 ------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
 Sphinx==3.1.2
+sphinx-argparse==0.2.5
+sphinx-rtd-theme==0.5.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-sphinx-rtd-theme==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    entry_points = {
+        'console_scripts': ['browser-history=browser_history.cli:main'],
+    }
 )


### PR DESCRIPTION
Update README. In Chromium browser replace 'Google Chrome'. Fix grammar mistake in index.rst

# Description

1. Sync README.md & quickstart.rst
2. Demonstrate get_history() in both.
3. Fix typo in index.rst
4. Replace "Google Chrome browser" to "Chromium Browser"

Fixes #17 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
