### PR TITLE
Documentation Modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ package to retrieve (almost) any browser's history on (almost) any platform.
 
 To get history from all installed browsers:
 ```python
-from browser_history.utils import get_history
+from browser_history import get_history
 
 outputs = get_history()
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ package to retrieve (almost) any browser's history on (almost) any platform.
 
 ## Usage
 
+To get history from all installed browsers:
+```python
+from browser_history.utils import get_history
+
+outputs = get_history()
+
+his = outputs.get()
+```
+ - `his` is a list of `(datetime.datetime, url)` tuples.
+
+
+If you want history from a specific browser:
 ```python
 from browser_history.browsers import Firefox
 

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -32,7 +32,7 @@ class Chrome(Browser):
         WHERE urls.id = visits.url ORDER BY visit_time DESC"""
 
 class Chromium(Browser):
-    """Google Chrome Browser
+    """Chromium Browser
 
     Supported platforms (TODO: Windows and Mac OS support)
 

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -52,7 +52,7 @@ def get_history():
     browsers for the system platform.
 
     :return: Object of class :py:class:`browser_history.generic.Outputs` with the
-    data member entries set to list(tuple(:py:class:`datetime.datetime`, str))
+        data member entries set to list(tuple(:py:class:`datetime.datetime`, str))
     
     :rtype: :py:class:`browser_history.generic.Outputs`
     """

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,8 +24,8 @@ Development Process - Short Version
 #. Work on the master branch for smaller patches and a separate branch for new features.
 #. Make changes, ``git add`` and then commit. Make sure to link the issue number in the commit message.
 #. Run the following commands: ``pylint browser_history``, ``pytest --cov=./browser_history``
-#. (Optional) If you're updating the documentation, run the following: ``cd docs``, ``make html``
-   and then open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.
+#. (Optional) If you're updating the documentation, make sure you update ``docs/quickstart.rst`` and ``README.md`` simultaneously.
+   Run the following: ``cd docs``, ``make html`` and then open ``_build/html/index.html`` in a browser to confirm that the documentation rendered correctly.
 #. If all tests are passing, pull changes from the original remote with a rebase, and push the changes to your remote repository.
 #. Use the GitHub website to create a Pull Request and wait for the maintainers to review it.
 
@@ -78,6 +78,8 @@ Development Process - Long Version
    * ``pytest --cov=./browser_history`` - ensure that all tests pass.
 
 #. (Optional) If you're updating the documentation, run the following:
+
+   .. caution:: Update ``docs/quickstart.rst`` and ``README.md`` simultaneously.
 
    * Change to the docs directory: ``cd docs``
    * Build the documentation: ``make html``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Check out the :ref:`quick_start` to get started.
 
 This project relies on contributions made by other people especially for browsers
 other than Chrome, Firefox and Safari and for platforms other than Windows, Mac
-and Linux. As such, if notice any issues or if there is no support for your browser
+and Linux. As such, if you notice any issues or if there is no support for your browser
 or platform, please open an issue on `the GitHub Page <https://github.com/pesos/browser-history>`_
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -17,7 +17,7 @@ Get started
 To get history from all installed browsers:
 ::
 
-    from browser_history.utils import get_history
+    from browser_history import get_history
 
     outputs = get_history()
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,13 +13,27 @@ Installation
 Get started
 -----------
 
+
+To get history from all installed browsers:
+::
+
+    from browser_history.utils import get_history
+
+    outputs = get_history()
+
+    his = outputs.get()
+
+- ``his`` is a list of ``(datetime.datetime, url)`` tuples.
+
+
+If you want history from a specific browser:
 ::
 
     from browser_history.browsers import Firefox
 
     f = Firefox.fetch()
 
-    histories = f.get()
+    his = f.get()
 
 - ``Firefox`` in the above snippet can be replaced with any of the :ref:`supported_browsers`.
 - ``his`` is a list of ``(datetime.datetime, url)`` tuples.


### PR DESCRIPTION
# Description
1. Fix the grammar issue in index.rst
2. Change "Google Chrome Browser" to "Chromium Browser" in doc string.
3. `make html` produces a warning - Fix it by add a tabspace to docstring in utils.get_history
4. Demonstrate get_history in readme & quickstart
5. Add the line "Simultaneous update for Quickstart & README" to contributing.rst

Fixes #17 

## Type of change

- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
