### PR TITLE
[ENHANCEMENT]Added foundation for exporting output to file

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -27,6 +27,18 @@ def make_parser():
                          help=f'''
                                 browser to retrieve history from. Should be one of all, {AVAILABLE_BROWSERS}.
                                 Default is all (gets history from all browsers).''')
+
+    parser_.add_argument('-f', '--format',
+                         default="csv",
+                         help=f'''
+                                Format to be used in output. Should be one of {generic.Outputs.formats}.
+                                Default is CSV''')
+
+    parser_.add_argument('-o', '--output',
+                         default=None,
+                         help='''
+                                File where output is to be written. 
+                                If not provided standard output is used.''')
     return parser_
 
 parser = make_parser()
@@ -61,6 +73,20 @@ def main():
             print(e)
             sys.exit(1)
 
-    for date, url in outputs.get():
-        # comma-separated output. NOT a CSV file
-        print(f'{date},{url}')
+    # Format the output
+    try:
+        formatted = outputs.formatted(args.format)
+    except ValueError as e:
+        print(e)
+        sys.exit(1)
+
+    if args.output is None:
+        print(formatted)
+    else:
+        filename = args.output
+        with open(filename, 'w') as output_file:
+            output_file.write(formatted)
+
+    # for date, url in outputs.get():
+    #     # comma-separated output. NOT a CSV file
+    #     print(f'{date},{url}')

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -86,7 +86,3 @@ def main():
         filename = args.output
         with open(filename, 'w') as output_file:
             output_file.write(formatted)
-
-    # for date, url in outputs.get():
-    #     # comma-separated output. NOT a CSV file
-    #     print(f'{date},{url}')

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -7,6 +7,7 @@ from browser_history import get_history, generic, browsers
 
 # get list of all implemented browser by finding subclasses of generic.Browser
 AVAILABLE_BROWSERS = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
+AVAILABLE_FORMATS = ', '.join(generic.Outputs.formats)
 
 def make_parser():
     """Creates an ArgumentParser, configures and returns it.
@@ -31,8 +32,8 @@ def make_parser():
     parser_.add_argument('-f', '--format',
                          default="csv",
                          help=f'''
-                                Format to be used in output. Should be one of {generic.Outputs.formats}.
-                                Default is CSV''')
+                                Format to be used in output. Should be one of {AVAILABLE_FORMATS}.
+                                Default is csv''')
 
     parser_.add_argument('-o', '--output',
                          default=None,

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -3,7 +3,8 @@ This module defines the generic base class and the functionaliity.
 
 All browsers from :py:mod:`browser_history.browsers` inherit this class.
 """
-
+import csv
+from io import StringIO
 from pathlib import Path
 from urllib.parse import urlparse
 from collections import defaultdict
@@ -183,10 +184,23 @@ class Outputs():
     * **entries**: List of tuples of Timestamp & URL
     :type entries: list(tuple(:py:class:`datetime.datetime`, str))
 
+    * **formats**: A tuple of strings containing all supported formats
+
+    * **fields**: The fields available for the history data returned
+
     """
+    # All formats added here should be implemented in _format_map
+    # Formats added here and in _format_map should be in lowercase
+    formats = ('csv', )
+    # Use the below fields for all formatter implementations
+    fields = ('Timestamp', 'URL')
 
     def __init__(self):
         self.entries = []
+        # format map is used by the formatted method to call the right formatter
+        self._format_map = {
+            'csv': self.to_csv,
+        }
 
     def get(self):
         """
@@ -208,3 +222,32 @@ class Outputs():
         for entry in self.entries:
             domain_histories[urlparse(entry[1]).netloc].append(entry)
         return domain_histories
+
+    def formatted(self, output_format='csv'):
+        """
+        Returns history as a :py:class:`str` formatted  as ``output_format``
+        :param output_format: One the formats in py:attr:`~formats`
+        :rtype: :py:class:`str` object
+        """
+        if self._format_map.get(output_format):
+            # fetch the required formatter in a case insensitive manner
+            formatter = self._format_map[output_format.lower()]
+            return formatter()
+        raise ValueError(f'Invalid format {output_format}. Should be one of {Outputs.formats}')
+
+    def to_csv(self):
+        """
+        Return history formatted as a comma separated string with the first row having the fields
+        names
+        :return:
+        """
+        # we will use csv module and let it do all the heavy lifting such as special character
+        # escaping and correct line termination escape sequences
+        # The catch is, we need to return a string but the csv module only works with files so we
+        # will use StringIO to build the csv in memory first
+        with StringIO() as output:
+            writer = csv.writer(output)
+            writer.writerow(Outputs.fields)
+            for row in self.get():
+                writer.writerow(row)
+            return output.getvalue()

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -229,9 +229,12 @@ class Outputs():
         :param output_format: One the formats in py:attr:`~formats`
         :rtype: :py:class:`str` object
         """
+        # convert to lower case since the formats tuple is enforced in lowercase
+        output_format = output_format.lower()
         if self._format_map.get(output_format):
-            # fetch the required formatter in a case insensitive manner
-            formatter = self._format_map[output_format.lower()]
+            # fetch the required formatter and call it. The formatters are instance methods
+            # so no need to pass any arguments
+            formatter = self._format_map[output_format]
             return formatter()
         raise ValueError(f'Invalid format {output_format}. Should be one of {Outputs.formats}')
 


### PR DESCRIPTION
# Description

Added method `formatted` which takes one argument `output_format` which is used to determine which formatter to use for the output history data. I also added class attributes `fields` and `formats` and private instance attribute `_format_map`, to make it easy for other contributors to add other output formats.

I also implemented the default format (CSV) by adding `to_csv` method to the `Outputs` class. This should provide a reference to other contributors implementing other formats.

Fixes #6
Fixes #34 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
