### PR TITLE
[CODE][FIX] Fix incomplete history while fetching from Firefox

### DIFF
--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -72,10 +72,10 @@ class Firefox(Browser):
 
     history_file = "places.sqlite"
     history_SQL = """SELECT
-            datetime(last_visit_date/1000000, 'unixepoch', 'localtime') AS 'visit_time',
+            datetime(visit_date/1000000, 'unixepoch', 'localtime') AS 'visit_time',
             url
-        FROM moz_historyvisits NATURAL JOIN moz_places WHERE
-        last_visit_date IS NOT NULL AND url LIKE 'http%' AND title IS NOT NULL"""
+        FROM moz_historyvisits INNER JOIN moz_places ON moz_historyvisits.place_id = moz_places.id 
+        WHERE visit_date IS NOT NULL AND url LIKE 'http%' AND title IS NOT NULL"""
 
 class Safari(Browser):
     """Apple Safari browser

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -11,20 +11,20 @@ def test_firefox_linux(become_linux, change_homedir):
     f = browser_history.browsers.Firefox()
     output = f.fetch()
     his = output.get()
-    assert len(his) == 1
-    assert his == [(datetime.datetime(2020, 8, 3, 0, 29, 4,
+    assert len(his) == 5
+    assert his[0] == (datetime.datetime(2020, 8, 3, 0, 29, 4,
                                       tzinfo=datetime.timezone(datetime.timedelta(seconds=19800),
                                                                'IST')),
-                    'https://www.mozilla.org/en-US/privacy/firefox/')]
+                    'https://www.mozilla.org/en-US/privacy/firefox/')
     profs = f.profiles()
     his_path = f.history_path_profile(profs[0])
     assert his_path == Path.home() / '.mozilla/firefox/profile/places.sqlite'
     his = f.history_profiles(profs).get()
-    assert len(his) == 1
-    assert his == [(datetime.datetime(2020, 8, 3, 0, 29, 4,
-                                      tzinfo=datetime.timezone(datetime.timedelta(seconds=19800),
-                                                               'IST')),
-                    'https://www.mozilla.org/en-US/privacy/firefox/')]
+    assert len(his) == 5
+    assert his[0] == (datetime.datetime(2020, 8, 3, 0, 29, 4,
+                                        tzinfo=datetime.timezone(datetime.timedelta(seconds=19800),
+                                                                 'IST')),
+                      'https://www.mozilla.org/en-US/privacy/firefox/')
 
 def test_edge_windows(become_windows, change_homedir):
     """Test history is correct for Edge on Windows"""


### PR DESCRIPTION
# Description
The section `NATURAL JOIN` in `Firefox.history_SQL` has been replaced with `INNER JOIN ON moz_historyvisits.place_id = moz_places.id` since `NATURAL JOIN` cannot implicitly handle the different field names `place_id` and `id`. Visit time will be derived from `moz_historyvisits.visit_date` and not `moz_places.last_visit_date` so as to capture all distinct visit times to the same URL. The test `test_firefox_linux` has also been modified to accommodate the new history entries that are returned due to this fix. 

Fixes #43 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
