### PR TITLE
[BUG FIX] History failing on windows

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -92,17 +92,15 @@ class Browser:
         if not self.profile_support:
             return ["."]
         profile_dirs = []
-        for profile_dir in Path(self.history_dir).rglob(str(self.history_file)):
-            path = (
-                str(profile_dir)
-                .split(str(self.history_dir), maxsplit=1)[-1]
-                .split(self.history_file, maxsplit=1)[0]
-            )
-            if path.startswith(os.sep):
-                path = path[1:]
-            if path.endswith(os.sep):
-                path = path[:-1]
-            profile_dirs.append(path)
+        for root, subFolder, files in os.walk(str(self.history_dir)):
+            for item in files:
+                if os.path.split(os.path.join(root,item))[-1] == self.history_file:
+                    path = str(root).split(str(self.history_dir), maxsplit=1)[-1]
+                    if path.startswith(os.sep):
+                        path = path[1:]
+                    if path.endswith(os.sep):
+                        path = path[:-1]
+                    profile_dirs.append(path)                            
         return profile_dirs
 
     def history_path_profile(self, profile_dir: Path) -> Path:

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -91,16 +91,18 @@ class Browser:
         """
         if not self.profile_support:
             return ["."]
-        file = glob.glob(
-            str(self.history_dir) + "/**/" + str(self.history_file), recursive=True
-        )
         profile_dirs = []
-        for profile_dir in file:
-            profile_dirs.append(
-                profile_dir.split(str(self.history_dir) + "/", maxsplit=1)[-1].split(
-                    "/" + self.history_file, maxsplit=1
-                )[0]
+        for profile_dir in Path(self.history_dir).rglob(str(self.history_file)):
+            path = (
+                str(profile_dir)
+                .split(str(self.history_dir), maxsplit=1)[-1]
+                .split(self.history_file, maxsplit=1)[0]
             )
+            if path.startswith(os.sep):
+                path = path[1:]
+            if path.endswith(os.sep):
+                path = path[:-1]
+            profile_dirs.append(path)
         return profile_dirs
 
     def history_path_profile(self, profile_dir: Path) -> Path:
@@ -200,17 +202,18 @@ class Outputs:
     * **fields**: The fields available for the history data returned
 
     """
+
     # All formats added here should be implemented in _format_map
     # Formats added here and in _format_map should be in lowercase
-    formats = ('csv', )
+    formats = ("csv",)
     # Use the below fields for all formatter implementations
-    fields = ('Timestamp', 'URL')
+    fields = ("Timestamp", "URL")
 
     def __init__(self):
         self.entries = []
         # format map is used by the formatted method to call the right formatter
         self._format_map = {
-            'csv': self.to_csv,
+            "csv": self.to_csv,
         }
 
     def get(self):
@@ -234,7 +237,7 @@ class Outputs:
             domain_histories[urlparse(entry[1]).netloc].append(entry)
         return domain_histories
 
-    def formatted(self, output_format='csv'):
+    def formatted(self, output_format="csv"):
         """
         Returns history as a :py:class:`str` formatted  as ``output_format``
         :param output_format: One the formats in py:attr:`~formats`
@@ -247,7 +250,9 @@ class Outputs:
             # so no need to pass any arguments
             formatter = self._format_map[output_format]
             return formatter()
-        raise ValueError(f'Invalid format {output_format}. Should be one of {Outputs.formats}')
+        raise ValueError(
+            f"Invalid format {output_format}. Should be one of {Outputs.formats}"
+        )
 
     def to_csv(self):
         """

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -14,6 +14,7 @@ import shutil
 import typing
 import datetime
 import glob
+import os
 import browser_history.utils as utils
 
 _local_tz = datetime.datetime.now().astimezone().tzinfo

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -92,15 +92,15 @@ class Browser:
         if not self.profile_support:
             return ["."]
         profile_dirs = []
-        for root, subFolder, files in os.walk(str(self.history_dir)):
-            for item in files:
-                if os.path.split(os.path.join(root,item))[-1] == self.history_file:
-                    path = str(root).split(str(self.history_dir), maxsplit=1)[-1]
+        for files in os.walk(str(self.history_dir)):
+            for item in files[2]:
+                if os.path.split(os.path.join(files[0],item))[-1] == self.history_file:
+                    path = str(files[0]).split(str(self.history_dir), maxsplit=1)[-1]
                     if path.startswith(os.sep):
                         path = path[1:]
                     if path.endswith(os.sep):
                         path = path[:-1]
-                    profile_dirs.append(path)                            
+                    profile_dirs.append(path)
         return profile_dirs
 
     def history_path_profile(self, profile_dir: Path) -> Path:

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -13,7 +13,6 @@ import tempfile
 import shutil
 import typing
 import datetime
-import glob
 import os
 import browser_history.utils as utils
 


### PR DESCRIPTION
# Description
The previous commit though worked for Linux and MAC-OS systems broke history fetching on Windows.I fixed it by using the rglob function from pathlib. I made sure to test it on Linux and Windows systems and it works fine. MAC-OS is yet to be tested . I would like a second confirmation as well for all the OS's so as to avoid such things in the future 

Fixes #58 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
