### PR TITLE
[FEATURE] add Windows and Mac OS to workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,11 +12,13 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
 
+    runs-on: ${{ matrix.platform }}
+    
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +29,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with pylint
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: tests
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, 'feature-*' ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ master, 'feature-*' ]
 
 jobs:
   build:
@@ -18,7 +18,7 @@ jobs:
         platform: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.platform }}
-    
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
# Description

Added Windows (latest) and Mac OS (latest) to the list of platforms to run the tests workflow on. This brings up the number of checks to 9. It should also prevent issues arising due to platform-specific changes.

Fixes #57 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] Any dependent and pending changes have been merged and published

## Note: The tests fail currently due to #58.