### PR TITLE
[FIX] Fix error when fetching history from uninstalled browsers

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -87,9 +87,13 @@ class Browser:
             self.profile_dir_prefixes.append("*")
 
     def profiles(self) -> typing.List[str]:
-        """Returns a list of profile directories
+        """Returns a list of profile directories. If the browser is supported on the current
+        platform but is not installed an empty list will be returned
         :rtype: list(str)
         """
+        if not os.path.exists(self.history_dir):
+            utils.logger.info('%s browser is not installed', self.name)
+            return []
         if not self.profile_support:
             return ["."]
         profile_dirs = []
@@ -160,7 +164,8 @@ class Browser:
             Default value set to False.
         :type asc: boolean
         :return: Object of class :py:class:`browser_history.generic.Outputs` with the
-            data member entries set to list(tuple(:py:class:`datetime.datetime`, str))
+            data member entries set to list(tuple(:py:class:`datetime.datetime`, str)).
+            If the browser is not installed, this object will be empty.
         :rtype: :py:class:`browser_history.generic.Outputs`
         """
         if history_paths is None:


### PR DESCRIPTION
# Description

This fixes bug which resulted in `FileNotFoundError` when trying to fetch history from browsers supported on the current platform but not installed on it. This fix addresses that problem by checking if `generic.Browser.history_dir` is a path existing on the system. If this path is non-existent then the browser is probably not installed on that system and this information is logged and an empty profiles list is returned. This check is performed inside `generic.Browser.profiles` since every other functionality present and future will have to start by determining the profiles present.

Fixes #60 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
