### PR TITLE
[Feature Added] Mac OS support added for Brave,Opera,Edge

### DIFF
--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -108,15 +108,17 @@ class Safari(Browser):
 class Edge(Browser):
     """Microsoft Edge Browser
 
-    Supported platforms (TODO: Mac OS support)
+    Supported platforms
 
     * Windows
+    * Mac OS
 
     Profile support: Yes
     """
     name = "Edge"
 
     windows_path = 'AppData/Local/Microsoft/Edge/User Data'
+    mac_path = 'Library/Application Support/Microsoft Edge'
 
     profile_support = True
     profile_dir_prefixes = Chrome.profile_dir_prefixes
@@ -127,9 +129,9 @@ class Edge(Browser):
 class Opera(Browser):
     """Opera Browser
 
-    Supported platforms (TODO: Mac OS support)
+    Supported platforms
 
-    * Linux, Windows
+    * Linux, Windows, Mac OS
 
     Profile support: No
     """
@@ -137,6 +139,7 @@ class Opera(Browser):
 
     linux_path = '.config/opera'
     windows_path = 'AppData/Roaming/Opera Software/Opera Stable'
+    mac_path = 'Library/Application Support/com.operasoftware.Opera'
 
     profile_support = False
 
@@ -168,12 +171,15 @@ class Brave(Browser):
     Supported platforms:
 
     * Linux
+    * Mac OS
 
     Profile support: Yes
     """
     name = "Brave"
 
     linux_path = '.config/BraveSoftware/Brave-Browser'
+    mac_path = 'Library/Application Support/BraveSoftware/Brave-Browser'
+
 
     profile_support = True
     profile_dir_prefixes = Chrome.profile_dir_prefixes

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -210,7 +210,7 @@ class Outputs:
     # All formats added here should be implemented in _format_map
     # Formats added here and in _format_map should be in lowercase
     formats = ("csv", "json")
-  
+
     # Use the below fields for all formatter implementations
     fields = ("Timestamp", "URL")
 


### PR DESCRIPTION
# Description

Mac OS path added for Brave,Edge and Opera browsers which enables support for Mac OS.

#42 
Fixes #1 
Fixes #32 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
