### PR TITLE
save() function in Outputs

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -48,10 +48,11 @@ def make_parser():
     parser_.add_argument(
         "-f",
         "--format",
-        default="csv",
+        default="infer",
         help=f"""
             Format to be used in output. Should be one of {AVAILABLE_FORMATS}.
-            Default is csv""",
+            Default is infer (it tries to infer it from the output file's extension. If no output file is given or
+            if the format can't be inferred, it defaults to csv)""",
     )
 
     parser_.add_argument(
@@ -113,11 +114,12 @@ def main():
 
     try:
         if args.output is None:
+            if args.format == "infer":
+                args.format = "csv"
             print(args.type + ":")
             print(fetch_map[args.type]["var"].formatted(args.format))
         elif not args.output is None:
-            with open(args.output, "w") as output_file:
-                output_file.write(fetch_map[args.type]["var"].formatted(args.format))
+            fetch_map[args.type]["var"].save(args.output, args.format)
 
     except ValueError as e:
         print(e)

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -51,8 +51,8 @@ def make_parser():
         default="infer",
         help=f"""
             Format to be used in output. Should be one of {AVAILABLE_FORMATS}.
-            Default is infer (it tries to infer it from the output file's extension. If no output file is given or
-            if the format can't be inferred, it defaults to csv)""",
+            Default is infer (it tries to infer it from the output file's extension. If no output file is given
+            it defaults to csv)""",
     )
 
     parser_.add_argument(

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -388,11 +388,12 @@ class Outputs:
             If not given, it will automatically be inferd from the file's extension
         """
         if output_format == "infer":
-            file_extension = os.path.splitext(filename)[1][1:]
-            if file_extension == "json":
-                output_format = "json"
-            else:
-                output_format = "csv"
+            output_format = os.path.splitext(filename)[1][1:]
+            if  not output_format in self.format_map:
+                raise ValueError(
+                    f"Invalid extension .{output_format}. Should be one of "
+                    f"{', '.join(self.format_map.keys())}"
+                )
 
         with open(filename, "w") as out_file:
             out_file.write(self.formatted(output_format))

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -377,3 +377,22 @@ class Outputs:
             )
 
         return json_string
+
+    def save(self, filename, output_format="infer"):
+        """
+        Saves history or bookmarks to a file. Infers the type from the given filename
+        extension. If the type could not be inferred, it defaults to csv.
+
+        :param filename: the name of the file.
+        :param output_format: (optional)One the formats in `csv`, `json`, `jsonl`.
+            If not given, it will automatically be inferd from the file's extension
+        """
+        if output_format == "infer":
+            file_extension = os.path.splitext(filename)[1][1:]
+            if file_extension == "json":
+                output_format = "json"
+            else:
+                output_format = "csv"
+
+        with open(filename, "w") as out_file:
+            out_file.write(self.formatted(output_format))


### PR DESCRIPTION
# Description

Added save() function to Outputs, which makes saving the bookmarks or the history easier and which infers the output format from the file's extension.

Fixes #73 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [X] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [X] I have performed a self-review of my own code (if applicable)
- [X] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [X] Any dependent and pending changes have been merged and published
