### PR TITLE
[FIX]Remove spurious history records

### DIFF
--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -38,9 +38,9 @@ class Chrome(Browser):
             datetime(visits.visit_time/1000000-11644473600, 'unixepoch', 'localtime') as 'visit_time',
             urls.url
         FROM
-            urls, visits
+            visits INNER JOIN urls ON visits.url = urls.id
         WHERE
-            urls.id = visits.url
+            visits.visit_duration > 0
         ORDER BY
             visit_time DESC
     """

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -112,50 +112,8 @@ def test_edge_windows(become_windows, change_homedir):
     output = e.fetch_history()
     his = output.histories
     # test history from all profiles
-    assert len(his) == 4
+    assert len(his) == 1
     assert his == [
-        (
-            datetime.datetime(
-                2020,
-                9,
-                23,
-                10,
-                22,
-                37,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), "India Standard Time"
-                ),
-            ),
-            "http://www.google.com/",
-        ),
-        (
-            datetime.datetime(
-                2020,
-                9,
-                23,
-                10,
-                22,
-                37,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), "India Standard Time"
-                ),
-            ),
-            "https://www.google.com/?gws_rd=ssl",
-        ),
-        (
-            datetime.datetime(
-                2020,
-                9,
-                23,
-                10,
-                22,
-                37,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), "India Standard Time"
-                ),
-            ),
-            "https://www.google.com/?gws_rd=ssl",
-        ),
         (
             datetime.datetime(
                 2020,


### PR DESCRIPTION
# Description

Updates Chrome `history_SQL` query to return only valid URL visits. Updated Edge test on windows which was affected by this issue.

Fixes #71 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
