### PR TITLE
[CLI] Use logger for CLI errors (#79)

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -3,7 +3,7 @@ command line interface of browser-history."""
 
 import sys
 import argparse
-from browser_history import get_history, generic, browsers
+from browser_history import get_history, generic, browsers, utils
 
 # get list of all implemented browser by finding subclasses of generic.Browser
 AVAILABLE_BROWSERS = ', '.join(b.__name__ for b in generic.Browser.__subclasses__())
@@ -64,21 +64,21 @@ def main():
                     break
             browser_class = getattr(browsers, selected_browser)
         except AttributeError:
-            print(f'Browser {args.browser} is unavailable. Check --help for available browsers')
+            utils.logger.error(f'Browser {args.browser} is unavailable. Check --help for available browsers')
             sys.exit(1)
 
         try:
             browser = browser_class().fetch()
             outputs = browser
         except AssertionError as e:
-            print(e)
+            utils.logger.error(e)
             sys.exit(1)
 
     # Format the output
     try:
         formatted = outputs.formatted(args.format)
     except ValueError as e:
-        print(e)
+        utils.logger.error(e)
         sys.exit(1)
 
     if args.output is None:

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -64,7 +64,8 @@ def main():
                     break
             browser_class = getattr(browsers, selected_browser)
         except AttributeError:
-            utils.logger.error(f'Browser {args.browser} is unavailable. Check --help for available browsers')
+            utils.logger.error('Browser %s is unavailable. Check --help for available browsers',
+                               args.browser)
             sys.exit(1)
 
         try:


### PR DESCRIPTION
Error prints are changd to use  utils.logger.error in cli.py
This refers issue #79

# Description

This change fixes #79, in that it replaces the use of the print statement with logger for error output in cli.py. The motiviation for this change is to display errors as such in the cli output - as logger outputs "ERROR: " with each error log.


Fixes #79 (issue)

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ X] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [ X] I have performed a self-review of my own code (if applicable)
- [X] My changes generate no new warnings 
- [X] Any dependent and pending changes have been merged and published
