### PR TITLE
[DOC] Browser class

### DIFF
--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -1,0 +1,20 @@
+name: "Pull Request Docs Check"
+on: 
+- pull_request
+- push
+
+jobs:
+  docs:
+
+    strategy:
+      matrix:
+        python-version: [3.8]
+        platform: ubuntu-latest
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"

--- a/.github/workflows/python-mypy.yml
+++ b/.github/workflows/python-mypy.yml
@@ -1,0 +1,31 @@
+name: tests
+
+on:
+  push:
+    branches: [ master, 'feature-*' ]
+  pull_request:
+    branches: [ master, 'feature-*' ]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Test with mypy
+      uses: jpetrucciani/mypy-check@master
+      with:
+        path: 'browser_history'

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -53,9 +53,9 @@ class Chrome(Browser):
         The returned datetimes are timezone-aware with the local timezone set
         by default
 
-        :param bookmark_path : the path of the bookmark file
-        :type bookmark_path : str
-        :return a list of tuples of bookmark information
+        :param bookmark_path: the path of the bookmark file
+        :type bookmark_path: str
+        :return: a list of tuples of bookmark information
         :rtype: list(tuple(:py:class:`datetime.datetime`, str, str, str))
         """
 
@@ -163,9 +163,9 @@ class Firefox(Browser):
         The returned datetimes are timezone-aware with the local timezone set
         by default
 
-        :param bookmark_path : the path of the bookmark file
-        :type bookmark_path : str
-        :return a list of tuples of bookmark information
+        :param bookmark_path: the path of the bookmark file
+        :type bookmark_path: str
+        :return: a list of tuples of bookmark information
         :rtype: list(tuple(:py:class:`datetime.datetime`, str, str, str))
         """
 

--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -7,4 +7,5 @@ Currently, all :ref:`supported_browsers` use the same generic class :py:class:`b
 
 .. autoclass:: browser_history.generic.Browser
    :members:
+   :private-members:
 


### PR DESCRIPTION
# Description

- add test using https://github.com/ammaraskar/sphinx-action
- change Browser class doc
- fix doc on Browsers and Outputs class
- include Browser class private member on documentation
- fix profile_dir_prefixes initiation, see https://stackoverflow.com/questions/9751554/list-as-a-member-of-a-python-class-why-is-its-contents-being-shared-across-all

Fixes #62

project can actually pass mypy test. i can add this to github worflow if requested

Sphinx-action workflow is based on their example and python-package.yml. It only work for linux environment

Based on documentation, some class field must be set for new browser 
but based on by given example it can be initiated with only one of the `path` field. 
There is also this SO question for some method to achieve this 
https://stackoverflow.com/questions/1151212/equivalent-of-notimplementederror-for-fields-in-python .

e: If the change on Browser class is too big or it is better on list format, i will revert commit related to that

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
