### PR TITLE
[CLI] Fix incorrect error message for invalid types

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -41,7 +41,7 @@ def make_parser():
         default="history",
         help=f"""
                 argument to decide whether to retrieve history or bookmarks.
-                Should be one of all, {AVAILABLE_TYPES}.
+                Should be one of {AVAILABLE_TYPES}.
                 Default is history.""",
     )
     parser_.add_argument(
@@ -92,9 +92,11 @@ def main():
         "bookmarks": {"var": b_outputs, "fun": get_bookmarks},
     }
 
-    assert (
-        args.type in fetch_map.keys()
-    ), f"Type should be one of all, {AVAILABLE_TYPES}"
+    if args.type not in fetch_map:
+        utils.logger.error(
+            "Type %s is unavailable." " Check --help for available types", args.type
+        )
+        sys.exit(1)
 
     if args.browser == "all":
         fetch_map[args.type]["var"] = fetch_map[args.type]["fun"]()
@@ -109,19 +111,15 @@ def main():
             browser_class = getattr(browsers, selected_browser)
         except AttributeError:
             utils.logger.error(
-                "Browser %s is unavailable." "Check --help for available browsers",
+                "Browser %s is unavailable." " Check --help for available browsers",
                 args.browser,
             )
             sys.exit(1)
 
-        try:
-            if args.type == "history":
-                fetch_map[args.type]["var"] = browser_class().fetch_history()
-            elif args.type == "bookmarks":
-                fetch_map[args.type]["var"] = browser_class().fetch_bookmarks()
-        except AssertionError as e:
-            utils.logger.error(e)
-            sys.exit(1)
+        if args.type == "history":
+            fetch_map[args.type]["var"] = browser_class().fetch_history()
+        elif args.type == "bookmarks":
+            fetch_map[args.type]["var"] = browser_class().fetch_bookmarks()
 
     try:
         if args.output is None:


### PR DESCRIPTION
# Description

Currently, when a user enters an incorrect type through the `-t` flag, the following unfriendly error message is displayed:
```python
Traceback (most recent call last):
  File "C:\Users\MANU\OneDrive\Projects\browser-history\runner.py", line 5, in <module>
    main()
  File "C:\Users\MANU\OneDrive\Projects\browser-history\browser_history\cli.py", line 95, in main
    assert (
AssertionError: Type should be one of all, history, bookmarks
```
This PR provides a better error message that is similar to that displayed when an invalid browser is entered hence providing a consistent user experience.
`ERROR: Type jgkhf is unavailable.Check --help for available types`

It also removes incorrect option `all` for type which was being suggested to the user. I believe we are yet to implement generation of all types (bookmarks, history, etc) in one command.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
