### PR TITLE
[TESTS] Remove test suite dependence on run directory

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from os import path
 import platform
 from pathlib import Path
 
@@ -7,10 +8,14 @@ import pytest
 @pytest.fixture()
 def change_homedir(monkeypatch):
     """Change home directory for all tests"""
+
+    # Safe approach to locating 'tests/' dir (always the dir of this module)
+    test_dir = path.dirname(path.abspath(__file__))
+
     monkeypatch.setattr(
         Path,
         "home",
-        lambda: Path(f"./tests/test_homedirs/{platform.system()}"),
+        lambda: Path(f"{test_dir}/test_homedirs/{platform.system()}"),
     )
 
     return platform.system()


### PR DESCRIPTION
# Description

Close #91 by setting the home directory relative to the location of the `utils` test module, which is in a fixed location in the repo, rather than the current working directory where the test is run, which is independent of the repo location.

This means that running the `pytest` command alone in `browser-history/` or in `browser-history/tests/`, or indeed the `pytest <relative or absolute path to browser-history(/tests)>` command in any directory on the filesystem, results in a test suite pass (assuming the machine is in a timezone that is not one causing issue as per #90).

This PR requires no dependency changes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [n/a] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
