### PR TITLE
[TESTS] Timezone awareness for history datetime comparison

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint pytest pytest-cov
+        pip install pylint pytest pytest-cov python-dateutil
     - name: Lint with pylint
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -9,6 +9,44 @@ from .utils import (  # noqa: F401; pylint: disable=unused-import
     change_homedir,
 )
 
+# Note: from Python >= 3.9 it is possible to use a built-in module, zoneinfo,
+# (https://docs.python.org/3/library/zoneinfo.html) to achieve timezone
+# awareness. For earlier versions, an external module must be used. Choose:
+from dateutil import tz
+
+
+# Instead setting this to the standard library timezone option:
+#     datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+# will cause failures for timezones e.g. 'Europe/London'
+# or 'Australia/Melbourne' due to DST effects.
+LOCAL_TIMEZONE = tz.gettz()
+
+
+def _detatch_timezone_stamp(hist, is_lone_item=True):
+    """Remove the timezone stamp from a datetime.datetime object.
+
+    This is so datetimes can be tested for correctness despite timezone
+    complications. Without removing the timezone stamp, we are comparing
+    objects like the following, where the timezones are equivalent but named
+    differently due to the means of extracting them:
+
+        datetime.datetime(<datetime tuple>, tzinfo=datetime.timezone(
+            datetime.timedelta(seconds=<delta>), 'AEDT'))
+
+        datetime.datetime(<datetime tuple>, tzinfo=tzfile('/etc/localtime')
+
+    but the datetime tuple should be, and is tested to be, the same in
+    both cases.
+    """
+    if is_lone_item:
+        return (hist[0].replace(tzinfo=None), hist[1])
+    else:
+        removed_tz_entries = []
+        for entry in hist:
+            removed_tz_entries.append((entry[0].replace(tzinfo=None), entry[1]))
+        return removed_tz_entries
+
+
 # pylint: disable=redefined-outer-name,unused-argument
 
 
@@ -18,7 +56,7 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
     output = f.fetch_history()
     his = output.histories
     assert len(his) == 5
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             8,
@@ -27,7 +65,9 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
             29,
             4,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "https://www.mozilla.org/en-US/privacy/firefox/",
     )
     profs = f.profiles(f.history_file)
@@ -35,7 +75,7 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
     assert his_path == Path.home() / ".mozilla/firefox/profile/places.sqlite"
     his = f.history_profiles(profs).histories
     assert len(his) == 5
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             8,
@@ -44,17 +84,20 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
             29,
             4,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "https://www.mozilla.org/en-US/privacy/firefox/",
     )
 
-def test_chrome_linux(become_linux, change_homedir):
+
+def test_chrome_linux(become_linux, change_homedir):  # noqa: F811
     """Test history is correct on Chrome for Linux"""
     f = browser_history.browsers.Chrome()
     output = f.fetch_history()
     his = output.histories
     assert len(his) == 2
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             10,
@@ -63,7 +106,9 @@ def test_chrome_linux(become_linux, change_homedir):
             34,
             30,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "www.github.com",
     )
     profs = f.profiles(f.history_file)
@@ -71,7 +116,7 @@ def test_chrome_linux(become_linux, change_homedir):
     assert his_path == Path.home() / ".config/google-chrome/History"
     his = f.history_profiles(profs).histories
     assert len(his) == 2
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             10,
@@ -80,18 +125,20 @@ def test_chrome_linux(become_linux, change_homedir):
             34,
             30,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "www.github.com",
     )
 
 
-def test_chromium_linux(become_linux, change_homedir):
+def test_chromium_linux(become_linux, change_homedir):  # noqa: F811
     """Test history is correct on Chromium for Linux"""
     f = browser_history.browsers.Chromium()
     output = f.fetch_history()
     his = output.histories
     assert len(his) == 2
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             10,
@@ -100,7 +147,9 @@ def test_chromium_linux(become_linux, change_homedir):
             34,
             30,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "www.github.com",
     )
     profs = f.profiles(f.history_file)
@@ -111,7 +160,7 @@ def test_chromium_linux(become_linux, change_homedir):
     ]
     his = f.history_profiles(profs).histories
     assert len(his) == 2
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             10,
@@ -120,7 +169,9 @@ def test_chromium_linux(become_linux, change_homedir):
             34,
             30,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "www.github.com",
     )
 
@@ -134,7 +185,7 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
     profs = f.profiles(f.history_file)
     assert len(profs) == 2
     # the history list is long so just check the first and last item
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             10,
@@ -145,10 +196,12 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
             tzinfo=datetime.timezone(
                 datetime.timedelta(seconds=10800), "E. Africa Standard Time"
             ),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "https://www.youtube.com/",
     )
-    assert his[-1] == (
+    assert _detatch_timezone_stamp(his[-1]) == (
         datetime.datetime(
             2020,
             10,
@@ -159,12 +212,14 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
             tzinfo=datetime.timezone(
                 datetime.timedelta(seconds=10800), "E. Africa Standard Time"
             ),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "https://www.reddit.com/",
     )
     # get history for second profile
     his = f.history_profiles(["Profile 2"]).histories
-    assert his == [
+    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
         (
             datetime.datetime(
                 2020,
@@ -177,7 +232,9 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
                     datetime.timedelta(seconds=10800),
                     "E. Africa Standard Time",
                 ),
-            ),
+            )
+            .astimezone(LOCAL_TIMEZONE)
+            .replace(tzinfo=None),
             "https://www.reddit.com/",
         )
     ]
@@ -190,7 +247,7 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
     his = output.histories
     # test history from all profiles
     assert len(his) == 1
-    assert his == [
+    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
         (
             datetime.datetime(
                 2020,
@@ -202,7 +259,9 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(
                     datetime.timedelta(seconds=19800), "India Standard Time"
                 ),
-            ),
+            )
+            .astimezone(LOCAL_TIMEZONE)
+            .replace(tzinfo=None),
             "https://pesos.github.io/",
         ),
     ]
@@ -217,7 +276,7 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
     )
     his = e.history_profiles(["Profile 2"]).histories
     assert len(his) == 1
-    assert his == [
+    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
         (
             datetime.datetime(
                 2020,
@@ -229,7 +288,9 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
                 tzinfo=datetime.timezone(
                     datetime.timedelta(seconds=19800), "India Standard Time"
                 ),
-            ),
+            )
+            .astimezone(LOCAL_TIMEZONE)
+            .replace(tzinfo=None),
             "https://pesos.github.io/",
         )
     ]
@@ -242,7 +303,7 @@ def test_safari_mac(become_mac, change_homedir):  # noqa: F811
     output = e.fetch_history()
     his = output.histories
     assert len(his) == 5
-    assert his[0] == (
+    assert _detatch_timezone_stamp(his[0]) == (
         datetime.datetime(
             2020,
             9,
@@ -251,11 +312,13 @@ def test_safari_mac(become_mac, change_homedir):  # noqa: F811
             34,
             28,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "https://www.apple.com/in/",
     )
     assert his[1][1] == "https://www.google.co.in/?client=safari&channel=mac_bm"
-    assert his[4] == (
+    assert _detatch_timezone_stamp(his[4]) == (
         datetime.datetime(
             2020,
             9,
@@ -264,17 +327,19 @@ def test_safari_mac(become_mac, change_homedir):  # noqa: F811
             35,
             8,
             tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
         "https://pesos.github.io/",
     )
 
 
-def test_opera_windows(become_windows, change_homedir):
+def test_opera_windows(become_windows, change_homedir):  # noqa: F811
     o = browser_history.browsers.Opera()
     outputs = o.fetch_history()
     his = outputs.histories
     assert len(his) == 2
-    assert his == [
+    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
         (
             datetime.datetime(
                 2020,
@@ -286,7 +351,9 @@ def test_opera_windows(become_windows, change_homedir):
                 tzinfo=datetime.timezone(
                     datetime.timedelta(seconds=10800), "E. Africa Standard Time"
                 ),
-            ),
+            )
+            .astimezone(LOCAL_TIMEZONE)
+            .replace(tzinfo=None),
             "https://www.youtube.com/",
         ),
         (
@@ -300,7 +367,9 @@ def test_opera_windows(become_windows, change_homedir):
                 tzinfo=datetime.timezone(
                     datetime.timedelta(seconds=10800), "E. Africa Standard Time"
                 ),
-            ),
+            )
+            .astimezone(LOCAL_TIMEZONE)
+            .replace(tzinfo=None),
             "https://github.com/",
         ),
     ]

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -22,10 +22,10 @@ from dateutil import tz
 LOCAL_TIMEZONE = tz.gettz()
 
 
-def _detatch_timezone_stamp(hist, is_lone_item=True):
-    """Remove the timezone stamp from a datetime.datetime object.
+def _detatch_timezone_stamp(hist):
+    """Remove the timezone associated with the datetime in a history entry.
 
-    This is so datetimes can be tested for correctness despite timezone
+    This is so the datetimes can be tested for correctness despite timezone
     complications. Without removing the timezone stamp, we are comparing
     objects like the following, where the timezones are equivalent but named
     differently due to the means of extracting them:
@@ -38,13 +38,7 @@ def _detatch_timezone_stamp(hist, is_lone_item=True):
     but the datetime tuple should be, and is tested to be, the same in
     both cases.
     """
-    if is_lone_item:
-        return (hist[0].replace(tzinfo=None), hist[1])
-    else:
-        removed_tz_entries = []
-        for entry in hist:
-            removed_tz_entries.append((entry[0].replace(tzinfo=None), entry[1]))
-        return removed_tz_entries
+    return (hist[0].replace(tzinfo=None), hist[1])
 
 
 # pylint: disable=redefined-outer-name,unused-argument
@@ -219,25 +213,23 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
     )
     # get history for second profile
     his = f.history_profiles(["Profile 2"]).histories
-    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
-        (
-            datetime.datetime(
-                2020,
-                10,
-                4,
-                14,
-                2,
-                14,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=10800),
-                    "E. Africa Standard Time",
-                ),
-            )
-            .astimezone(LOCAL_TIMEZONE)
-            .replace(tzinfo=None),
-            "https://www.reddit.com/",
+    assert _detatch_timezone_stamp(his[0]) == (
+        datetime.datetime(
+            2020,
+            10,
+            4,
+            14,
+            2,
+            14,
+            tzinfo=datetime.timezone(
+                datetime.timedelta(seconds=10800),
+                "E. Africa Standard Time",
+            ),
         )
-    ]
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
+        "https://www.reddit.com/",
+    )
 
 
 def test_edge_windows(become_windows, change_homedir):  # noqa: F811
@@ -247,24 +239,22 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
     his = output.histories
     # test history from all profiles
     assert len(his) == 1
-    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
-        (
-            datetime.datetime(
-                2020,
-                9,
-                23,
-                10,
-                45,
-                3,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), "India Standard Time"
-                ),
-            )
-            .astimezone(LOCAL_TIMEZONE)
-            .replace(tzinfo=None),
-            "https://pesos.github.io/",
-        ),
-    ]
+    assert _detatch_timezone_stamp(his[0]) == (
+        datetime.datetime(
+            2020,
+            9,
+            23,
+            10,
+            45,
+            3,
+            tzinfo=datetime.timezone(
+                datetime.timedelta(seconds=19800), "India Standard Time"
+            ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
+        "https://pesos.github.io/",
+    )
 
     # test history from specific profile
     profs = e.profiles(e.history_file)
@@ -276,24 +266,22 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
     )
     his = e.history_profiles(["Profile 2"]).histories
     assert len(his) == 1
-    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
-        (
-            datetime.datetime(
-                2020,
-                9,
-                23,
-                10,
-                45,
-                3,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=19800), "India Standard Time"
-                ),
-            )
-            .astimezone(LOCAL_TIMEZONE)
-            .replace(tzinfo=None),
-            "https://pesos.github.io/",
+    assert _detatch_timezone_stamp(his[0]) == (
+        datetime.datetime(
+            2020,
+            9,
+            23,
+            10,
+            45,
+            3,
+            tzinfo=datetime.timezone(
+                datetime.timedelta(seconds=19800), "India Standard Time"
+            ),
         )
-    ]
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
+        "https://pesos.github.io/",
+    )
 
 
 def test_safari_mac(become_mac, change_homedir):  # noqa: F811
@@ -339,38 +327,37 @@ def test_opera_windows(become_windows, change_homedir):  # noqa: F811
     outputs = o.fetch_history()
     his = outputs.histories
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his, is_lone_item=False) == [
-        (
-            datetime.datetime(
-                2020,
-                10,
-                13,
-                12,
-                4,
-                51,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=10800), "E. Africa Standard Time"
-                ),
-            )
-            .astimezone(LOCAL_TIMEZONE)
-            .replace(tzinfo=None),
-            "https://www.youtube.com/",
-        ),
-        (
-            datetime.datetime(
-                2020,
-                10,
-                13,
-                12,
-                4,
-                59,
-                tzinfo=datetime.timezone(
-                    datetime.timedelta(seconds=10800), "E. Africa Standard Time"
-                ),
-            )
-            .astimezone(LOCAL_TIMEZONE)
-            .replace(tzinfo=None),
-            "https://github.com/",
-        ),
-    ]
+    assert _detatch_timezone_stamp(his[0]) == (
+        datetime.datetime(
+            2020,
+            10,
+            13,
+            12,
+            4,
+            51,
+            tzinfo=datetime.timezone(
+                datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+            ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
+        "https://www.youtube.com/",
+    )
+    assert len(his) == 2
+    assert _detatch_timezone_stamp(his[1]) == (
+        datetime.datetime(
+            2020,
+            10,
+            13,
+            12,
+            4,
+            59,
+            tzinfo=datetime.timezone(
+                datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+            ),
+        )
+        .astimezone(LOCAL_TIMEZONE)
+        .replace(tzinfo=None),
+        "https://github.com/",
+    )
     assert len(o.profiles(o.history_file)) == 1

--- a/tests/test_browsers.py
+++ b/tests/test_browsers.py
@@ -7,38 +7,8 @@ from .utils import (  # noqa: F401; pylint: disable=unused-import
     become_mac,
     become_windows,
     change_homedir,
+    assert_histories_equal,
 )
-
-# Note: from Python >= 3.9 it is possible to use a built-in module, zoneinfo,
-# (https://docs.python.org/3/library/zoneinfo.html) to achieve timezone
-# awareness. For earlier versions, an external module must be used. Choose:
-from dateutil import tz
-
-
-# Instead setting this to the standard library timezone option:
-#     datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
-# will cause failures for timezones e.g. 'Europe/London'
-# or 'Australia/Melbourne' due to DST effects.
-LOCAL_TIMEZONE = tz.gettz()
-
-
-def _detatch_timezone_stamp(hist):
-    """Remove the timezone associated with the datetime in a history entry.
-
-    This is so the datetimes can be tested for correctness despite timezone
-    complications. Without removing the timezone stamp, we are comparing
-    objects like the following, where the timezones are equivalent but named
-    differently due to the means of extracting them:
-
-        datetime.datetime(<datetime tuple>, tzinfo=datetime.timezone(
-            datetime.timedelta(seconds=<delta>), 'AEDT'))
-
-        datetime.datetime(<datetime tuple>, tzinfo=tzfile('/etc/localtime')
-
-    but the datetime tuple should be, and is tested to be, the same in
-    both cases.
-    """
-    return (hist[0].replace(tzinfo=None), hist[1])
 
 
 # pylint: disable=redefined-outer-name,unused-argument
@@ -50,38 +20,40 @@ def test_firefox_linux(become_linux, change_homedir):  # noqa: F811
     output = f.fetch_history()
     his = output.histories
     assert len(his) == 5
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            8,
-            3,
-            0,
-            29,
-            4,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.mozilla.org/en-US/privacy/firefox/",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                8,
+                3,
+                0,
+                29,
+                4,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
+            ),
+            "https://www.mozilla.org/en-US/privacy/firefox/",
+        ),
     )
     profs = f.profiles(f.history_file)
     his_path = f.history_path_profile(profs[0])
     assert his_path == Path.home() / ".mozilla/firefox/profile/places.sqlite"
     his = f.history_profiles(profs).histories
     assert len(his) == 5
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            8,
-            3,
-            0,
-            29,
-            4,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.mozilla.org/en-US/privacy/firefox/",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                8,
+                3,
+                0,
+                29,
+                4,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
+            ),
+            "https://www.mozilla.org/en-US/privacy/firefox/",
+        ),
     )
 
 
@@ -91,38 +63,40 @@ def test_chrome_linux(become_linux, change_homedir):  # noqa: F811
     output = f.fetch_history()
     his = output.histories
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            15,
-            15,
-            34,
-            30,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "www.github.com",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                15,
+                15,
+                34,
+                30,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
+            ),
+            "www.github.com",
+        ),
     )
     profs = f.profiles(f.history_file)
     his_path = f.history_path_profile(profs[0])
     assert his_path == Path.home() / ".config/google-chrome/History"
     his = f.history_profiles(profs).histories
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            15,
-            15,
-            34,
-            30,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "www.github.com",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                15,
+                15,
+                34,
+                30,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
+            ),
+            "www.github.com",
+        ),
     )
 
 
@@ -132,19 +106,20 @@ def test_chromium_linux(become_linux, change_homedir):  # noqa: F811
     output = f.fetch_history()
     his = output.histories
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            15,
-            15,
-            34,
-            30,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "www.github.com",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                15,
+                15,
+                34,
+                30,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
+            ),
+            "www.github.com",
+        ),
     )
     profs = f.profiles(f.history_file)
     his_path = f.history_path_profile(profs[0])
@@ -154,19 +129,20 @@ def test_chromium_linux(become_linux, change_homedir):  # noqa: F811
     ]
     his = f.history_profiles(profs).histories
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            15,
-            15,
-            34,
-            30,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "www.github.com",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                15,
+                15,
+                34,
+                30,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), "CEST"),
+            ),
+            "www.github.com",
+        ),
     )
 
 
@@ -179,56 +155,59 @@ def test_firefox_windows(become_windows, change_homedir):  # noqa: F811
     profs = f.profiles(f.history_file)
     assert len(profs) == 2
     # the history list is long so just check the first and last item
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            1,
-            11,
-            43,
-            35,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                1,
+                11,
+                43,
+                35,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.youtube.com/",
+            "https://www.youtube.com/",
+        ),
     )
-    assert _detatch_timezone_stamp(his[-1]) == (
-        datetime.datetime(
-            2020,
-            10,
-            4,
-            14,
-            2,
-            14,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+    assert_histories_equal(
+        his[-1],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                4,
+                14,
+                2,
+                14,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.reddit.com/",
+            "https://www.reddit.com/",
+        ),
     )
     # get history for second profile
     his = f.history_profiles(["Profile 2"]).histories
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            4,
-            14,
-            2,
-            14,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=10800),
-                "E. Africa Standard Time",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                4,
+                14,
+                2,
+                14,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=10800),
+                    "E. Africa Standard Time",
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.reddit.com/",
+            "https://www.reddit.com/",
+        ),
     )
 
 
@@ -239,21 +218,22 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
     his = output.histories
     # test history from all profiles
     assert len(his) == 1
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            9,
-            23,
-            10,
-            45,
-            3,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=19800), "India Standard Time"
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                9,
+                23,
+                10,
+                45,
+                3,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=19800), "India Standard Time"
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://pesos.github.io/",
+            "https://pesos.github.io/",
+        ),
     )
 
     # test history from specific profile
@@ -266,21 +246,22 @@ def test_edge_windows(become_windows, change_homedir):  # noqa: F811
     )
     his = e.history_profiles(["Profile 2"]).histories
     assert len(his) == 1
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            9,
-            23,
-            10,
-            45,
-            3,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=19800), "India Standard Time"
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                9,
+                23,
+                10,
+                45,
+                3,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=19800), "India Standard Time"
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://pesos.github.io/",
+            "https://pesos.github.io/",
+        ),
     )
 
 
@@ -291,34 +272,36 @@ def test_safari_mac(become_mac, change_homedir):  # noqa: F811
     output = e.fetch_history()
     his = output.histories
     assert len(his) == 5
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            9,
-            29,
-            23,
-            34,
-            28,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.apple.com/in/",
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                9,
+                29,
+                23,
+                34,
+                28,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
+            ),
+            "https://www.apple.com/in/",
+        ),
     )
     assert his[1][1] == "https://www.google.co.in/?client=safari&channel=mac_bm"
-    assert _detatch_timezone_stamp(his[4]) == (
-        datetime.datetime(
-            2020,
-            9,
-            29,
-            23,
-            35,
-            8,
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://pesos.github.io/",
+    assert_histories_equal(
+        his[4],
+        (
+            datetime.datetime(
+                2020,
+                9,
+                29,
+                23,
+                35,
+                8,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), "IST"),
+            ),
+            "https://pesos.github.io/",
+        ),
     )
 
 
@@ -327,37 +310,39 @@ def test_opera_windows(become_windows, change_homedir):  # noqa: F811
     outputs = o.fetch_history()
     his = outputs.histories
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his[0]) == (
-        datetime.datetime(
-            2020,
-            10,
-            13,
-            12,
-            4,
-            51,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+    assert_histories_equal(
+        his[0],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                13,
+                12,
+                4,
+                51,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://www.youtube.com/",
+            "https://www.youtube.com/",
+        ),
     )
     assert len(his) == 2
-    assert _detatch_timezone_stamp(his[1]) == (
-        datetime.datetime(
-            2020,
-            10,
-            13,
-            12,
-            4,
-            59,
-            tzinfo=datetime.timezone(
-                datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+    assert_histories_equal(
+        his[1],
+        (
+            datetime.datetime(
+                2020,
+                10,
+                13,
+                12,
+                4,
+                59,
+                tzinfo=datetime.timezone(
+                    datetime.timedelta(seconds=10800), "E. Africa Standard Time"
+                ),
             ),
-        )
-        .astimezone(LOCAL_TIMEZONE)
-        .replace(tzinfo=None),
-        "https://github.com/",
+            "https://github.com/",
+        ),
     )
     assert len(o.profiles(o.history_file)) == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from dateutil import tz
 import platform
 from pathlib import Path
 
@@ -38,3 +39,44 @@ def become_linux(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Linux")
 
     return platform.system()
+
+
+def _detach_timezone_stamp(hist):
+    """Remove the timezone associated with the datetime in a history entry.
+
+    This is so the datetimes can be tested for correctness despite timezone
+    complications. Without removing the timezone stamp, we are comparing
+    objects like the following, where the timezones are equivalent but named
+    differently due to the means of extracting them:
+
+        datetime.datetime(<datetime tuple>, tzinfo=datetime.timezone(
+            datetime.timedelta(seconds=<delta>), 'AEDT'))
+
+        datetime.datetime(<datetime tuple>, tzinfo=tzfile('/etc/localtime')
+
+    but the datetime tuple should be, and is tested to be, the same in
+    both cases.
+    """
+    return (hist[0].replace(tzinfo=None), hist[1])
+
+
+def assert_histories_equal(actual_history, expected_history):
+    """Assert that two histories are equal, accounting for differing timezones.
+
+    Use of any Python standard library timezone-management option, such as:
+
+        datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+
+    instead of a dedicated external library, notably here dateutil.tz, would
+    result in failures for certain timezones e.g. 'Europe/London' or
+    'Australia/Melbourne' due to DST effects.
+
+    Note that from Python >= 3.9 it is possible to use a built-in module,
+    zoneinfo (https://docs.python.org/3/library/zoneinfo.html) to achieve
+    timezone awareness. For earlier versions, an external module must be used.
+    """
+    local_timezone = tz.gettz()
+
+    assert _detach_timezone_stamp(actual_history) == _detach_timezone_stamp(
+        (expected_history[0].astimezone(local_timezone), expected_history[1])
+    )


### PR DESCRIPTION
# Description

Close #90 by making the `test_browser` history comparisons check for equivalence of datetimes in a way that is properly timezone aware due to use of the `dateutil.tz` module.

I wanted to avoid the need for any external module even in the test modules, given that the core codebase of `browser-history` has zero dependencies, but unfortunately after much investigation I found it was not possible to solve the issue without importing a truly timezone-aware library (`pytz` is another that will work) into the test in question. However, in Python 3.9 there is a built-in solution `zoneinfo` which can be used, so in future the new dependency can be removed with a tweak of the test to use that instead.

However, given the tests themselves require the `pytest` external library to run, I think it should be okay to add one dependency to the test requirements? I should stress again that it really isn't possible to solve the issue at the moment without an external library that manages timezones.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [n/a] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published