### PR TITLE
[REFACTOR] Add generic ChromiumBasedBrowser class

### DIFF
--- a/browser_history/__init__.py
+++ b/browser_history/__init__.py
@@ -1,4 +1,30 @@
+import inspect
 from . import browsers, generic, utils  # noqa: F401
+
+
+def get_browsers():
+    """This method provides a list of all browsers implemented by
+    browser_history.
+
+    :return: A :py:class:`list` containing implemented browser classes
+        all inheriting from the super class
+        :py:class:`browser_history.generic.Browser`
+
+    :rtype: :py:class:`list`
+    """
+
+    # recursively get all concrete subclasses
+    def get_subclasses(browser):
+        # include browser itself in return list if it is concrete
+        sub_classes = []
+        if not inspect.isabstract(browser):
+            sub_classes.append(browser)
+
+        for sub_class in browser.__subclasses__():
+            sub_classes.extend(get_subclasses(sub_class))
+        return sub_classes
+
+    return get_subclasses(generic.Browser)
 
 
 def get_history():
@@ -12,8 +38,8 @@ def get_history():
     :rtype: :py:class:`browser_history.generic.Outputs`
     """
     output_object = generic.Outputs(fetch_type="history")
-    subclasses = generic.Browser.__subclasses__()
-    for browser_class in subclasses:
+    browser_classes = get_browsers()
+    for browser_class in browser_classes:
         try:
             browser_object = browser_class()
             browser_output_object = browser_object.fetch_history()
@@ -35,7 +61,7 @@ def get_bookmarks():
     :rtype: :py:class:`browser_history.generic.Outputs`
     """
     output_object = generic.Outputs(fetch_type="bookmarks")
-    subclasses = generic.Browser.__subclasses__()
+    subclasses = get_browsers()
     for browser_class in subclasses:
         try:
             browser_object = browser_class()

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -3,14 +3,12 @@
 All browsers must inherit from :py:mod:`browser_history.generic.Browser`.
 """
 import datetime
-import json
-import os
 import sqlite3
 
-from browser_history.generic import Browser
+from browser_history.generic import Browser, ChromiumBasedBrowser
 
 
-class Chrome(Browser):
+class Chromium(ChromiumBasedBrowser):
     """Google Chrome Browser
 
     Supported platforms:
@@ -22,77 +20,13 @@ class Chrome(Browser):
     Profile support: Yes
     """
 
-    name = "Chrome"
+    name = "Chromium"
 
-    windows_path = "AppData/Local/Google/Chrome/User Data"
-    mac_path = "Library/Application Support/Google/Chrome/"
-    linux_path = ".config/google-chrome"
-
-    profile_support = True
-    profile_dir_prefixes = ["Default*", "Profile*"]
-
-    history_file = "History"
-    bookmarks_file = "Bookmarks"
-
-    history_SQL = """
-        SELECT
-            datetime(
-                visits.visit_time/1000000-11644473600, 'unixepoch', 'localtime'
-            ) as 'visit_time',
-            urls.url
-        FROM
-            visits INNER JOIN urls ON visits.url = urls.id
-        WHERE
-            visits.visit_duration > 0
-        ORDER BY
-            visit_time DESC
-    """
-
-    def bookmarks_parser(self, bookmark_path):
-        """Returns bookmarks of a single profile for Chrome based browsers
-        The returned datetimes are timezone-aware with the local timezone set
-        by default
-
-        :param bookmark_path: the path of the bookmark file
-        :type bookmark_path: str
-        :return: a list of tuples of bookmark information
-        :rtype: list(tuple(:py:class:`datetime.datetime`, str, str, str))
-        """
-
-        def _deeper(array, folder, bookmarks_list):
-            for node in array:
-                if node["type"] == "url":
-                    d_t = datetime.datetime(1601, 1, 1) + datetime.timedelta(
-                        microseconds=int(node["date_added"])
-                    )
-                    bookmarks_list.append(
-                        (
-                            d_t.replace(microsecond=0, tzinfo=self._local_tz),
-                            node["url"],
-                            node["name"],
-                            folder,
-                        )
-                    )
-                else:
-                    bookmarks_list = _deeper(
-                        node["children"],
-                        folder + os.sep + node["name"],
-                        bookmarks_list,
-                    )
-            return bookmarks_list
-
-        with open(bookmark_path) as b_p:
-            b_m = json.load(b_p)
-            bookmarks_list = []
-            for root in b_m["roots"]:
-                if isinstance(b_m["roots"][root], dict):
-                    bookmarks_list = _deeper(
-                        b_m["roots"][root]["children"], root, bookmarks_list
-                    )
-        return bookmarks_list
+    linux_path = ".config/chromium"
+    windows_path = "AppData/Local/chromium/User Data"
 
 
-class Chromium(Browser):
+class Chrome(ChromiumBasedBrowser):
     """Chromium Browser
 
     Supported platforms (TODO: Mac OS support)
@@ -103,20 +37,11 @@ class Chromium(Browser):
     Profile support: Yes
     """
 
-    name = "Chromium"
+    name = "Chrome"
 
-    linux_path = ".config/chromium"
-    windows_path = "AppData/Local/chromium/User Data"
-
-    profile_support = True
-    profile_dir_prefixes = Chrome.profile_dir_prefixes
-
-    history_file = Chrome.history_file
-    bookmarks_file = Chrome.bookmarks_file
-
-    history_SQL = Chrome.history_SQL
-
-    bookmarks_parser = Chrome.bookmarks_parser
+    windows_path = "AppData/Local/Google/Chrome/User Data"
+    mac_path = "Library/Application Support/Google/Chrome/"
+    linux_path = ".config/google-chrome"
 
 
 class Firefox(Browser):
@@ -236,7 +161,7 @@ class Safari(Browser):
     """
 
 
-class Edge(Browser):
+class Edge(ChromiumBasedBrowser):
     """Microsoft Edge Browser
 
     Supported platforms
@@ -252,18 +177,8 @@ class Edge(Browser):
     windows_path = "AppData/Local/Microsoft/Edge/User Data"
     mac_path = "Library/Application Support/Microsoft Edge"
 
-    profile_support = True
-    profile_dir_prefixes = Chrome.profile_dir_prefixes
 
-    history_file = Chrome.history_file
-    bookmarks_file = Chrome.bookmarks_file
-
-    history_SQL = Chrome.history_SQL
-
-    bookmarks_parser = Chrome.bookmarks_parser
-
-
-class Opera(Browser):
+class Opera(ChromiumBasedBrowser):
     """Opera Browser
 
     Supported platforms
@@ -281,15 +196,8 @@ class Opera(Browser):
 
     profile_support = False
 
-    history_file = Chrome.history_file
-    bookmarks_file = Chrome.bookmarks_file
 
-    history_SQL = Chrome.history_SQL
-
-    bookmarks_parser = Chrome.bookmarks_parser
-
-
-class OperaGX(Browser):
+class OperaGX(ChromiumBasedBrowser):
     """Opera GX Browser
 
     Supported platforms
@@ -305,15 +213,8 @@ class OperaGX(Browser):
 
     profile_support = False
 
-    history_file = Chrome.history_file
-    bookmarks_file = Chrome.bookmarks_file
 
-    history_SQL = Chrome.history_SQL
-
-    bookmarks_parser = Chrome.bookmarks_parser
-
-
-class Brave(Browser):
+class Brave(ChromiumBasedBrowser):
     """Brave Browser
 
     Supported platforms:
@@ -328,13 +229,3 @@ class Brave(Browser):
 
     linux_path = ".config/BraveSoftware/Brave-Browser"
     mac_path = "Library/Application Support/BraveSoftware/Brave-Browser"
-
-    profile_support = True
-    profile_dir_prefixes = Chrome.profile_dir_prefixes
-
-    history_file = Chrome.history_file
-    bookmarks_file = Chrome.bookmarks_file
-
-    history_SQL = Chrome.history_SQL
-
-    bookmarks_parser = Chrome.bookmarks_parser

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -9,13 +9,12 @@ from browser_history.generic import Browser, ChromiumBasedBrowser
 
 
 class Chromium(ChromiumBasedBrowser):
-    """Google Chrome Browser
+    """Chromium Browser
 
-    Supported platforms:
+    Supported platforms (TODO: Mac OS support)
 
-    * Windows
     * Linux
-    * Mac OS
+    * Windows
 
     Profile support: Yes
     """
@@ -27,12 +26,13 @@ class Chromium(ChromiumBasedBrowser):
 
 
 class Chrome(ChromiumBasedBrowser):
-    """Chromium Browser
+    """Google Chrome Browser
 
-    Supported platforms (TODO: Mac OS support)
+    Supported platforms:
 
-    * Linux
     * Windows
+    * Linux
+    * Mac OS
 
     Profile support: Yes
     """

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -24,6 +24,8 @@ class Chromium(ChromiumBasedBrowser):
     linux_path = ".config/chromium"
     windows_path = "AppData/Local/chromium/User Data"
 
+    profile_support = True
+
 
 class Chrome(ChromiumBasedBrowser):
     """Google Chrome Browser
@@ -42,6 +44,8 @@ class Chrome(ChromiumBasedBrowser):
     windows_path = "AppData/Local/Google/Chrome/User Data"
     mac_path = "Library/Application Support/Google/Chrome/"
     linux_path = ".config/google-chrome"
+
+    profile_support = True
 
 
 class Firefox(Browser):
@@ -177,6 +181,8 @@ class Edge(ChromiumBasedBrowser):
     windows_path = "AppData/Local/Microsoft/Edge/User Data"
     mac_path = "Library/Application Support/Microsoft Edge"
 
+    profile_support = True
+
 
 class Opera(ChromiumBasedBrowser):
     """Opera Browser
@@ -229,3 +235,5 @@ class Brave(ChromiumBasedBrowser):
 
     linux_path = ".config/BraveSoftware/Brave-Browser"
     mac_path = "Library/Application Support/BraveSoftware/Brave-Browser"
+
+    profile_support = True

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -8,12 +8,13 @@ from browser_history import (
     browsers,
     generic,
     get_bookmarks,
+    get_browsers,
     get_history,
     utils,
 )
 
 # get list of all implemented browser by finding subclasses of generic.Browser
-AVAILABLE_BROWSERS = ", ".join(b.__name__ for b in generic.Browser.__subclasses__())
+AVAILABLE_BROWSERS = ", ".join(b.__name__ for b in get_browsers())
 AVAILABLE_FORMATS = ", ".join(generic.Outputs(fetch_type=None).format_map.keys())
 AVAILABLE_TYPES = ", ".join(generic.Outputs(fetch_type=None).field_map.keys())
 
@@ -104,7 +105,7 @@ def main():
         try:
             # gets browser class by name (string).
             selected_browser = args.browser
-            for browser in generic.Browser.__subclasses__():
+            for browser in get_browsers():
                 if browser.__name__.lower() == args.browser.lower():
                     selected_browser = browser.__name__
                     break

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -525,3 +525,80 @@ class Outputs:
 
         with open(filename, "w") as out_file:
             out_file.write(self.formatted(output_format))
+
+
+class ChromiumBasedBrowser(Browser, abc.ABC):
+    """A generic class to support the increasing number of Chromium based
+    browsers.
+
+    .. note::
+
+        This generic class assumes all chromium based browsers support
+        profiles but that may not be the case. Ensure :py:attr:`profile_support`
+        is overridden correctly if so.
+
+    """
+
+    profile_dir_prefixes = ["Default*", "Profile*"]
+
+    history_file = "History"
+    bookmarks_file = "Bookmarks"
+
+    profile_support = True
+
+    history_SQL = """
+            SELECT
+                datetime(
+                    visits.visit_time/1000000-11644473600, 'unixepoch', 'localtime'
+                ) as 'visit_time',
+                urls.url
+            FROM
+                visits INNER JOIN urls ON visits.url = urls.id
+            WHERE
+                visits.visit_duration > 0
+            ORDER BY
+                visit_time DESC
+        """
+
+    def bookmarks_parser(self, bookmark_path):
+        """Returns bookmarks of a single profile for Chrome based browsers
+        The returned datetimes are timezone-aware with the local timezone set
+        by default
+
+        :param bookmark_path: the path of the bookmark file
+        :type bookmark_path: str
+        :return: a list of tuples of bookmark information
+        :rtype: list(tuple(:py:class:`datetime.datetime`, str, str, str))
+        """
+
+        def _deeper(array, folder, bookmarks_list):
+            for node in array:
+                if node["type"] == "url":
+                    d_t = datetime.datetime(1601, 1, 1) + datetime.timedelta(
+                        microseconds=int(node["date_added"])
+                    )
+                    bookmarks_list.append(
+                        (
+                            d_t.replace(microsecond=0, tzinfo=self._local_tz),
+                            node["url"],
+                            node["name"],
+                            folder,
+                        )
+                    )
+                else:
+                    bookmarks_list = _deeper(
+                        node["children"],
+                        folder + os.sep + node["name"],
+                        bookmarks_list,
+                    )
+            return bookmarks_list
+
+        with open(bookmark_path) as b_p:
+            b_m = json.load(b_p)
+            bookmarks_list = []
+            for root in b_m["roots"]:
+                if isinstance(b_m["roots"][root], dict):
+                    bookmarks_list = _deeper(
+                        b_m["roots"][root]["children"], root, bookmarks_list
+                    )
+        return bookmarks_list

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -530,21 +530,12 @@ class Outputs:
 class ChromiumBasedBrowser(Browser, abc.ABC):
     """A generic class to support the increasing number of Chromium based
     browsers.
-
-    .. note::
-
-        This generic class assumes all chromium based browsers support
-        profiles but that may not be the case. Ensure :py:attr:`profile_support`
-        is overridden correctly if so.
-
     """
 
     profile_dir_prefixes = ["Default*", "Profile*"]
 
     history_file = "History"
     bookmarks_file = "Bookmarks"
-
-    profile_support = True
 
     history_SQL = """
             SELECT


### PR DESCRIPTION
# Description

This PR adds a new abstract class `ChromiumBasedBrowser` in `generic.py`. This makes it easier for future contributors to add support for new chromium based browsers. As a consequence of this change, trying to access all browsers using `generic.Browser.__subclasses__()` doesn't work anymore. To solve this problem, I have added the `browser_history.get_browsers` function to recursively search for concrete browser classes starting from the abstract class `generic.Browser`
Fixes #104 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [ ] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
