### PR TITLE
[TESTS] Test module and refactor for CLI

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -81,12 +81,12 @@ def make_parser():
 parser = make_parser()
 
 
-def main():
+def cli(args):
     """Entrypoint to the command-line interface (CLI) of browser-history.
 
     It parses arguments from sys.argv and performs the appropriate actions.
     """
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     outputs = None
     fetch_map = {
         "history": get_history,
@@ -126,7 +126,6 @@ def main():
         if args.output is None:
             if args.format == "infer":
                 args.format = "csv"
-            print(args.type + ":")
             print(outputs.formatted(args.format))
         elif args.output is not None:
             outputs.save(args.output, args.format)
@@ -134,3 +133,7 @@ def main():
     except ValueError as e:
         utils.logger.error(e)
         sys.exit(1)
+
+
+def main():
+    cli(sys.argv[1:])

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -286,6 +286,9 @@ class Browser(abc.ABC):
         :rtype: :py:class:`browser_history.generic.Outputs`
         """
 
+        assert (
+            self.bookmarks_file is not None
+        ), "Bookmarks are not supported for {} browser".format(self.name)
         if bookmarks_paths is None:
             bookmarks_paths = self.paths(profile_file=self.bookmarks_file)
         output_object = Outputs(fetch_type="bookmarks")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,213 @@
+import csv
+import itertools
+import json
+import subprocess
+import tempfile
+
+import pytest
+
+
+CMD_ROOT = "browser-history"
+
+# Options:
+VALID_CMD_OPTS = [
+    (f"--{long_o}", f"-{short_o}")
+    for long_o, short_o in [
+        ("help", "h"),
+        ("type", "t"),
+        ("browser", "b"),
+        ("format", "f"),
+        ("output", "o"),
+    ]
+]
+INVALID_CMD_OPTS = [
+    "--history",
+    "-a",
+    "-B",
+    "-0",
+]
+
+# Arguments, where the default arg should be put first for default testing:
+VALID_TYPE_ARGS = [
+    "history",
+    "bookmarks",
+    # "all",  # Note: this is only commented out because there is a bug!
+]
+VALID_BROWSER_ARGS = [
+    "all",
+    "Chrome",
+    "Chromium",
+    "Firefox",
+    "Safari",
+    "Edge",
+    "Opera",
+    "OperaGX",
+    "Brave",
+]
+VALID_FORMAT_ARGS = [
+    "infer",
+    "csv",
+    "json",
+    "jsonl",
+]
+# (VALID_OUTPUT_ARGS is any existent file, so validity depends on the fs)
+GENERAL_INVALID_ARGS = [
+    "foo",
+    "0",
+]
+
+# Output markers:
+HELP_SIGNATURE = (
+    "usage: browser-history " "[-h] [-t TYPE] [-b BROWSER] [-f FORMAT] [-o OUTPUT]"
+)
+HISTORY_TITLE = "history:\n"
+BOOKMARKS_TITLE = "bookmarks:\n"
+HISTORY_HEADER = "Timestamp,URL"
+BOOKMARKS_HEADER = "Timestamp,URL,Title,Folder"
+
+CSV_HISTORY_HEADER = HISTORY_TITLE + HISTORY_HEADER
+CSV_BOOKMARKS_HEADER = BOOKMARKS_TITLE + BOOKMARKS_HEADER
+
+
+def test_no_argument():
+    """Test the root command gives basic output."""
+    output = subprocess.check_output([CMD_ROOT])
+    assert CSV_HISTORY_HEADER in output.decode("utf-8")
+
+
+def test_type_argument():
+    """Test arguments for the type option."""
+    for type_opt in VALID_CMD_OPTS[1]:
+        for type_arg in VALID_TYPE_ARGS:
+            output = subprocess.check_output([CMD_ROOT, type_opt, type_arg]).decode(
+                "utf-8"
+            )
+            if type_arg == "history":  # in ('history', 'all')
+                assert output.startswith(HISTORY_TITLE)
+            if type_arg == "bookmarks":  # in ('bookmarks', 'all')
+                assert output.startswith(BOOKMARKS_TITLE)
+
+
+@pytest.mark.parametrize("browser_arg", VALID_BROWSER_ARGS)
+def test_browser_argument(browser_arg):
+    """Test arguments for the browser option."""
+    for browser_opt in VALID_CMD_OPTS[2]:
+        output = subprocess.Popen(
+            [CMD_ROOT, browser_opt, browser_arg],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = output.communicate()
+        if output.returncode == 0:
+            assert CSV_HISTORY_HEADER in stdout.decode("utf-8")
+        elif any(
+            browser_unavailable_err in stderr.decode("utf-8")
+            for browser_unavailable_err in (
+                "browser is not supported",
+                "browser is not installed",
+            )
+        ):
+            # In case the tester does not have access to the browser
+            # in question, which makes the command fail, but in a way
+            # that is expected and gives a recognised error message.
+            pytest.skip(
+                "Unable to test against this browser because it is "
+                "not available locally"
+            )
+        else:  # command fails for another reason i.e. a test failure
+            pytest.fail(
+                "The browser is available but the command to fetch "
+                "the history from it has failed."
+            )
+
+
+def test_format_argument():
+    """Tests arguments for the format option."""
+    # First check format of default:
+    csv_output = subprocess.check_output([CMD_ROOT]).decode("utf-8")
+    # Sniffer determines format, less intensive than reading in csv.reader
+    # and we don't mind the CSV dialect, so just check call doesn't error
+    read_csv = csv.Sniffer()
+    read_csv.sniff(csv_output, delimiters=",")
+    read_csv.has_header(csv_output)
+
+    for fmt_opt in VALID_CMD_OPTS[3]:
+        for fmt_arg in VALID_FORMAT_ARGS:
+            output = subprocess.check_output([CMD_ROOT, fmt_opt, fmt_arg]).decode(
+                "utf-8"
+            )
+            if fmt_arg in ("csv", "infer"):  # infer gives csv if no file
+                csv.Sniffer().sniff(output, delimiters=",")
+                csv.Sniffer().has_header(output)
+                assert CSV_HISTORY_HEADER in output
+            elif fmt_arg == "json":
+                assert output.startswith(HISTORY_TITLE)
+                # Need to strip header off before checking for valid json
+                json.loads(output.lstrip(HISTORY_TITLE))
+            else:  # i.e. fmt_arg == 'jsonl':
+                assert output.startswith(HISTORY_TITLE)
+                jsonl_output = output.lstrip(HISTORY_TITLE)
+                # Newline-delimited json so test each line is valid json
+                for line in jsonl_output.splitlines():
+                    json.loads(line)
+
+
+def test_output_argument():
+    """Test arguments for the output option."""
+    for output_opt in VALID_CMD_OPTS[4]:
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            output = subprocess.check_output([CMD_ROOT, output_opt, f.name])
+            # Check output was not sent to STDOUT since should go to file
+            assert HISTORY_HEADER not in output.decode("utf-8")
+            with open(f.name, "rb") as f:  # now check the file
+                assert HISTORY_HEADER in f.read().decode("utf-8")
+
+
+def test_argument_combinations():
+    """Test that combinations of optional arguments work properly."""
+    # Choose some representative combinations. No need to test every one.
+    indices = (0, 1)
+    # To test combos of short or long option variants
+    for index_a, index_b in itertools.product(indices, indices):
+        chrome_bookmarks_output = subprocess.check_output(
+            [
+                CMD_ROOT,
+                VALID_CMD_OPTS[1][index_a],  # type
+                VALID_TYPE_ARGS[1],  # ... is bookmarks,
+                VALID_CMD_OPTS[2][index_a],  # browser
+                VALID_BROWSER_ARGS[1],  # ... is Chrome
+            ]
+        ).decode("utf-8")
+        assert chrome_bookmarks_output.startswith(BOOKMARKS_TITLE)
+        assert not chrome_bookmarks_output.startswith(HISTORY_TITLE)
+        read_csv = csv.Sniffer()
+        read_csv.sniff(chrome_bookmarks_output, delimiters=",")
+        read_csv.has_header(chrome_bookmarks_output)
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            # This command should write to the given output file:
+            subprocess.check_output(
+                [
+                    CMD_ROOT,
+                    VALID_CMD_OPTS[3][index_b],  # format
+                    VALID_FORMAT_ARGS[2],  # ... is json,
+                    VALID_CMD_OPTS[4][index_b],  # output
+                    f.name,  # ... is a named file
+                ]
+            ).decode("utf-8")
+            with open(f.name, "rb") as f:
+                json.loads(f.read().decode("utf-8"))
+
+
+def test_help_option():
+    """Test the command-line help provided to the user on request."""
+    for help_opt in VALID_CMD_OPTS[0]:
+        output = subprocess.check_output([CMD_ROOT, help_opt]).decode("utf-8")
+        assert HELP_SIGNATURE in output
+
+
+def test_invalid_options():
+    """Test that invalid options error correctly."""
+    for bad_opt in INVALID_CMD_OPTS:
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_output([CMD_ROOT, bad_opt]).decode("utf-8")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,20 @@
 import csv
 import itertools
 import json
-import subprocess
 import tempfile
 
 import pytest
 
 from browser_history import get_browsers
+from browser_history.cli import cli, AVAILABLE_BROWSERS
+from .utils import (  # noqa: F401
+    become_linux,
+    become_mac,
+    become_windows,
+    change_homedir,
+)
 
+# pylint: disable=redefined-outer-name,unused-argument
 
 CMD_ROOT = "browser-history"
 
@@ -61,13 +68,26 @@ GENERAL_INVALID_ARGS = [
 HELP_SIGNATURE = (
     "usage: browser-history " "[-h] [-t TYPE] [-b BROWSER] [-f FORMAT] [-o OUTPUT]"
 )
-HISTORY_TITLE = "history:\n"
-BOOKMARKS_TITLE = "bookmarks:\n"
 HISTORY_HEADER = "Timestamp,URL"
 BOOKMARKS_HEADER = "Timestamp,URL,Title,Folder"
 
-CSV_HISTORY_HEADER = HISTORY_TITLE + HISTORY_HEADER
-CSV_BOOKMARKS_HEADER = BOOKMARKS_TITLE + BOOKMARKS_HEADER
+CSV_HISTORY_HEADER = HISTORY_HEADER
+CSV_BOOKMARKS_HEADER = BOOKMARKS_HEADER
+
+
+platform_fixture_map = {
+    "linux": become_linux,
+    "windows": become_windows,
+    "mac": become_mac,
+}
+all_platform_fixtures = tuple("become_" + plat for plat in platform_fixture_map.keys())
+
+
+@pytest.fixture
+def platform(request):
+    """Fixture to change platform based on pytest parameter"""
+    request.getfixturevalue("change_homedir")
+    return request.getfixturevalue(request.param)
 
 
 def _get_browser_available_on_system():
@@ -84,63 +104,66 @@ def _get_browser_available_on_system():
     return  # None indicating no browsers available on system
 
 
-def test_no_argument():
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+def test_no_argument(capsys, platform):
     """Test the root command gives basic output."""
-    output = subprocess.check_output(CMD_ROOT, shell=True)
-    assert CSV_HISTORY_HEADER in output.decode("utf-8")
+    cli([])
+    captured = capsys.readouterr()
+    assert CSV_HISTORY_HEADER in captured.out
 
 
-def test_type_argument():
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+def test_type_argument(capsys, platform):
     """Test arguments for the type option."""
     for type_opt in VALID_CMD_OPTS[1]:
         for type_arg in VALID_TYPE_ARGS:
-            output = subprocess.check_output(
-                " ".join([CMD_ROOT, type_opt, type_arg]), shell=True
-            ).decode("utf-8")
+            cli([type_opt, type_arg])
+            captured = capsys.readouterr()
             if type_arg == "history":
-                assert output.startswith(HISTORY_TITLE)
+                # assuming csv is default
+                assert captured.out.startswith(CSV_HISTORY_HEADER)
             if type_arg == "bookmarks":
-                assert output.startswith(BOOKMARKS_TITLE)
+                assert captured.out.startswith(CSV_BOOKMARKS_HEADER)
 
 
 @pytest.mark.parametrize("browser_arg", VALID_BROWSER_ARGS)
-def test_browser_argument(browser_arg):
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+def test_browser_argument(browser_arg, capsys, platform):
     """Test arguments for the browser option."""
     for browser_opt in VALID_CMD_OPTS[2]:
-        output = subprocess.Popen(
-            " ".join([CMD_ROOT, browser_opt, browser_arg]),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True,
-        )
-        stdout, stderr = output.communicate()
-        if output.returncode == 0:
-            assert CSV_HISTORY_HEADER in stdout.decode("utf-8")
-        elif any(
-            browser_unavailable_err in stderr.decode("utf-8")
-            for browser_unavailable_err in (
-                "browser is not supported",
-                "browser is not installed",
-            )
-        ):
-            # In case the tester does not have access to the browser
-            # in question, which makes the command fail, but in a way
-            # that is expected and gives a recognised error message.
-            pytest.skip(
-                "Unable to test against {} browser because it is "
-                "not available locally".format(browser_opt)
-            )
-        else:  # command fails for another reason i.e. a test failure
-            pytest.fail(
-                "{} browser is available but the command to fetch "
-                "the history from it has failed.".format(browser_opt)
-            )
+        try:
+            cli([browser_opt, browser_arg])
+            captured = capsys.readouterr()
+            assert CSV_HISTORY_HEADER in captured.out
+        except AssertionError as e:
+            if any(
+                browser_unavailable_err in e.args[0]
+                for browser_unavailable_err in (
+                    "browser is not supported",
+                    "browser is not installed",
+                )
+            ):
+                # In case the tester does not have access to the browser
+                # in question, which makes the command fail, but in a way
+                # that is expected and gives a recognised error message.
+                pytest.skip(
+                    "Unable to test against {} browser because it is "
+                    "not available locally".format(browser_opt)
+                )
+            else:  # command fails for another reason i.e. a test failure
+                pytest.fail(
+                    "{} browser is available but the command to fetch "
+                    "the history from it has failed.".format(browser_opt)
+                )
 
 
-def test_format_argument():
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+def test_format_argument(capsys, platform):
     """Tests arguments for the format option."""
     # First check format of default:
-    csv_output = subprocess.check_output(CMD_ROOT, shell=True).decode("utf-8")
+    cli([])
+    captured = capsys.readouterr()
+    csv_output = captured.out
     # Sniffer determines format, less intensive than reading in csv.reader
     # and we don't mind the CSV dialect, so just check call doesn't error
     read_csv = csv.Sniffer()
@@ -152,39 +175,36 @@ def test_format_argument():
 
     for fmt_opt in VALID_CMD_OPTS[3]:
         for fmt_arg in VALID_FORMAT_ARGS:
-            output = subprocess.check_output(
-                " ".join([CMD_ROOT, fmt_opt, fmt_arg]), shell=True
-            ).decode("utf-8")
+            cli([fmt_opt, fmt_arg])
+            output = capsys.readouterr().out
             if fmt_arg in ("csv", "infer"):  # infer gives csv if no file
                 read_csv.sniff(output, delimiters=",")
                 assert read_csv.has_header(output)
                 assert CSV_HISTORY_HEADER in output
             elif fmt_arg == "json":
-                assert output.startswith(HISTORY_TITLE)
-                # Need to strip header off before checking for valid json
-                json.loads(output.lstrip(HISTORY_TITLE))
-            else:  # i.e. fmt_arg == 'jsonl':
-                assert output.startswith(HISTORY_TITLE)
-                jsonl_output = output.lstrip(HISTORY_TITLE)
+                json.loads(output)
+            elif fmt_arg == "jsonl":
                 # Newline-delimited json so test each line is valid json
-                for line in jsonl_output.splitlines():
+                for line in output.splitlines():
                     json.loads(line)
 
 
-def test_output_argument():
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+def test_output_argument(capsys, platform):
     """Test arguments for the output option."""
     for output_opt in VALID_CMD_OPTS[4]:
         with tempfile.NamedTemporaryFile(suffix=".csv") as f:
-            output = subprocess.check_output(
-                " ".join([CMD_ROOT, output_opt, f.name]), shell=True
-            )
+            cli([output_opt, f.name])
+            output = capsys.readouterr().out
             # Check output was not sent to STDOUT since should go to file
-            assert HISTORY_HEADER not in output.decode("utf-8")
-            with open(f.name, "rb") as f:  # now check the file
-                assert HISTORY_HEADER in f.read().decode("utf-8")
+            assert HISTORY_HEADER not in output
+            with open(f.name, "rt") as f:  # now check the file
+                assert HISTORY_HEADER in f.read()
 
 
-def test_argument_combinations():
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+@pytest.mark.parametrize("browser", AVAILABLE_BROWSERS.split(", "))
+def test_argument_combinations(capsys, platform, browser):
     """Test that combinations of optional arguments work properly."""
     # Choose some representative combinations. No need to test every one.
     indices = (0, 1)
@@ -192,57 +212,71 @@ def test_argument_combinations():
     # To test combos of short or long option variants
     for index_a, index_b in itertools.product(indices, indices):
         if available_browser:
-            chrome_bookmarks_output = subprocess.check_output(
-                " ".join(
+            try:
+                cli(
                     [
-                        CMD_ROOT,
                         VALID_CMD_OPTS[1][index_a],  # type
                         VALID_TYPE_ARGS[1],  # ... is bookmarks,
                         VALID_CMD_OPTS[2][index_a],  # browser
-                        available_browser,  # ... is any usable on system
+                        browser,  # ... is any usable on system
                     ]
-                ),
-                shell=True,
-            ).decode("utf-8")
-            assert chrome_bookmarks_output.startswith(BOOKMARKS_TITLE)
-            assert not chrome_bookmarks_output.startswith(HISTORY_TITLE)
+                )
+            except AssertionError as e:
+                if any(
+                    browser_unavailable_err in e.args[0]
+                    for browser_unavailable_err in (
+                        "browser is not supported",
+                        "browser is not installed",
+                        "Bookmarks are not supported",
+                    )
+                ):
+                    # In case the tester does not have access to the browser
+                    # in question, which makes the command fail, but in a way
+                    # that is expected and gives a recognised error message.
+                    pytest.skip(
+                        "Unable to test against {} browser because it is "
+                        "not available locally".format(browser)
+                    )
+                else:  # command fails for another reason i.e. a test failure
+                    pytest.fail(
+                        "{} browser is available but the command to fetch "
+                        "the history from it has failed.".format(browser)
+                    )
+            output = capsys.readouterr().out
+
             read_csv = csv.Sniffer()
-            read_csv.sniff(chrome_bookmarks_output, delimiters=",")
-            assert read_csv.has_header(chrome_bookmarks_output)
+            read_csv.sniff(output, delimiters=",")
+            assert read_csv.has_header(output)
         else:  # unlikely but catch just in case can't use any browser
             for _ in range(3):  # to cover all three assert tests above
                 pytest.skip("No browsers available to test with")
         with tempfile.NamedTemporaryFile(suffix=".csv") as f:
             # This command should write to the given output file:
-            subprocess.check_output(
-                " ".join(
-                    [
-                        CMD_ROOT,
-                        VALID_CMD_OPTS[3][index_b],  # format
-                        VALID_FORMAT_ARGS[2],  # ... is json,
-                        VALID_CMD_OPTS[4][index_b],  # output
-                        f.name,  # ... is a named file
-                    ]
-                ),
-                shell=True,
-            ).decode("utf-8")
+            cli(
+                [
+                    VALID_CMD_OPTS[3][index_b],  # format
+                    VALID_FORMAT_ARGS[2],  # ... is json,
+                    VALID_CMD_OPTS[4][index_b],  # output
+                    f.name,  # ... is a named file
+                ]
+            )
             with open(f.name, "rb") as f:
                 json.loads(f.read().decode("utf-8"))
 
 
-def test_help_option():
+def test_help_option(capsys):
     """Test the command-line help provided to the user on request."""
     for help_opt in VALID_CMD_OPTS[0]:
-        output = subprocess.check_output(
-            " ".join([CMD_ROOT, help_opt]), shell=True
-        ).decode("utf-8")
-        assert HELP_SIGNATURE in output
+        with pytest.raises(SystemExit) as e:
+            cli([help_opt])
+            output = capsys.readouterr()
+            assert HELP_SIGNATURE in output
+            assert e.value.code == 0
 
 
-def test_invalid_options():
+def test_invalid_options(capsys):
     """Test that invalid options error correctly."""
     for bad_opt in INVALID_CMD_OPTS:
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_output(" ".join([CMD_ROOT, bad_opt]), shell=True).decode(
-                "utf-8"
-            )
+        with pytest.raises(SystemExit) as e:
+            cli([bad_opt])
+            assert e.value.code == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,6 @@ INVALID_CMD_OPTS = [
 VALID_TYPE_ARGS = [
     "history",
     "bookmarks",
-    # "all",  # Note: this is only commented out because there is a bug!
 ]
 VALID_BROWSER_ARGS = [
     "all",
@@ -128,8 +127,9 @@ def test_format_argument():
     # Sniffer determines format, less intensive than reading in csv.reader
     # and we don't mind the CSV dialect, so just check call doesn't error
     read_csv = csv.Sniffer()
+    # This gives '_csv.Error: Could not determine delimiter' if not a csv file
     read_csv.sniff(csv_output, delimiters=",")
-    read_csv.has_header(csv_output)
+    assert read_csv.has_header(csv_output)
 
     for fmt_opt in VALID_CMD_OPTS[3]:
         for fmt_arg in VALID_FORMAT_ARGS:
@@ -137,8 +137,8 @@ def test_format_argument():
                 "utf-8"
             )
             if fmt_arg in ("csv", "infer"):  # infer gives csv if no file
-                csv.Sniffer().sniff(output, delimiters=",")
-                csv.Sniffer().has_header(output)
+                read_csv.sniff(output, delimiters=",")
+                assert read_csv.has_header(output)
                 assert CSV_HISTORY_HEADER in output
             elif fmt_arg == "json":
                 assert output.startswith(HISTORY_TITLE)
@@ -155,7 +155,7 @@ def test_format_argument():
 def test_output_argument():
     """Test arguments for the output option."""
     for output_opt in VALID_CMD_OPTS[4]:
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".csv") as f:
             output = subprocess.check_output([CMD_ROOT, output_opt, f.name])
             # Check output was not sent to STDOUT since should go to file
             assert HISTORY_HEADER not in output.decode("utf-8")
@@ -182,9 +182,9 @@ def test_argument_combinations():
         assert not chrome_bookmarks_output.startswith(HISTORY_TITLE)
         read_csv = csv.Sniffer()
         read_csv.sniff(chrome_bookmarks_output, delimiters=",")
-        read_csv.has_header(chrome_bookmarks_output)
+        assert read_csv.has_header(chrome_bookmarks_output)
 
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".csv") as f:
             # This command should write to the given output file:
             subprocess.check_output(
                 [


### PR DESCRIPTION
# Description

Fixes #65 by adding a test module to cover the command-line interface. **Still TODO in order to fix that Issue is the refactor of the CLI itself, but now I have a test it will be much simpler to gauge that the refactor has retained the previous behaviour.**

These new tests are, I believe, quite straightforward, with the only slight complication being that some browsers will not be available to a given machine running the tests, so tests running commands to grab the history from a given browser may need to be skipped. To skip those as appropriate on a browser-by-browser basis, I have created a parameterised test with the browser names as the parameters, so the result of running them (in verbose mode for illustration purposes, `pytest -v -v`)  is as follows:

```py
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /home/sadie/anaconda3/envs/cf-env/bin/python
cachedir: .pytest_cache
rootdir: /home/sadie/browser-history
collected 29 items                                                             

tests/test_browsers.py::test_firefox_linux PASSED                        [  3%]
tests/test_browsers.py::test_chrome_linux PASSED                         [  6%]
tests/test_browsers.py::test_chromium_linux PASSED                       [ 10%]
tests/test_browsers.py::test_firefox_windows PASSED                      [ 13%]
tests/test_browsers.py::test_edge_windows PASSED                         [ 17%]
tests/test_browsers.py::test_safari_mac PASSED                           [ 20%]
tests/test_browsers.py::test_opera_windows PASSED                        [ 24%]
tests/test_cli.py::test_no_argument PASSED                               [ 27%]
tests/test_cli.py::test_type_argument PASSED                             [ 31%]
tests/test_cli.py::test_browser_argument[all] PASSED                     [ 34%]
tests/test_cli.py::test_browser_argument[Chrome] PASSED                  [ 37%]
tests/test_cli.py::test_browser_argument[Chromium] PASSED                [ 41%]
tests/test_cli.py::test_browser_argument[Firefox] PASSED                 [ 44%]
tests/test_cli.py::test_browser_argument[Safari] SKIPPED                 [ 48%]
tests/test_cli.py::test_browser_argument[Edge] SKIPPED                   [ 51%]
tests/test_cli.py::test_browser_argument[Opera] PASSED                   [ 55%]
tests/test_cli.py::test_browser_argument[OperaGX] SKIPPED                [ 58%]
tests/test_cli.py::test_browser_argument[Brave] PASSED                   [ 62%]
tests/test_cli.py::test_format_argument PASSED                           [ 65%]
tests/test_cli.py::test_output_argument PASSED                           [ 68%]
tests/test_cli.py::test_argument_combinations PASSED                     [ 72%]
tests/test_cli.py::test_help_option PASSED                               [ 75%]
tests/test_cli.py::test_invalid_options PASSED                           [ 79%]
tests/test_generic.py::test_outputs_init PASSED                          [ 82%]
tests/test_generic.py::test_output_to_csv[entries0-Timestamp,URL\r\n] PASSED [ 86%]
tests/test_generic.py::test_output_to_csv[entries1-Timestamp,URL\r\n2020-01-01 00:00:00,https://google.com\r\n2020-01-01 00:00:00,https://example.com\r\n] PASSED [ 89%]
tests/test_generic.py::test_output_sort_domain[entries0-exp_res0] PASSED [ 93%]
tests/test_generic.py::test_output_sort_domain[entries1-exp_res1] PASSED [ 96%]
tests/test_import.py::test_nothing PASSED                                [100%]

======================== 26 passed, 3 skipped in 10.10s ========================

```
Note that it has skipped Safari etc. since those browsers are not available for my machine, but tested on any that are.

By the way, I originally created this as a `unittest.TestCase` class of test methods rather than individual functions, but I changed to the latter when I decided it would be useful to use the `@pytest.mark.parametrize` pytest fixture for the browser command option test, since pytest fixtures can't be used with `unittest.TestCase` subclasses.

No new dependencies are required.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue) [*not strictly a bug, but fixes a raised issue, so of the enumerated options this was most appropriate*]

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [n/a] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
