### PR TITLE
[FIX] Fixed bug in bookmarks

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -562,25 +562,32 @@ class ChromiumBasedBrowser(Browser, abc.ABC):
         :rtype: list(tuple(:py:class:`datetime.datetime`, str, str, str))
         """
 
-        def _deeper(array, folder, bookmarks_list):
-            for node in array:
-                if node["type"] == "url":
-                    d_t = datetime.datetime(1601, 1, 1) + datetime.timedelta(
-                        microseconds=int(node["date_added"])
-                    )
-                    bookmarks_list.append(
-                        (
-                            d_t.replace(microsecond=0, tzinfo=self._local_tz),
-                            node["url"],
-                            node["name"],
-                            folder,
-                        )
-                    )
+        def _deeper(bookmarks_json, folder, bookmarks_list):
+            for node in bookmarks_json:
+                if node == "children":
+                    for child in bookmarks_json[node]:
+                        if child["type"] == "url":
+                            d_t = datetime.datetime(1601, 1, 1) + datetime.timedelta(
+                                microseconds=int(child["date_added"])
+                            )
+                            bookmarks_list.append(
+                                (
+                                    d_t.replace(microsecond=0, tzinfo=self._local_tz),
+                                    child["url"],
+                                    child["name"],
+                                    folder,
+                                )
+                            )
+                        elif child["type"] == "folder":
+                            bookmarks_list = _deeper(
+                                child,
+                                folder + os.sep + child["name"],
+                                bookmarks_list,
+                            )
+                    break
                 else:
                     bookmarks_list = _deeper(
-                        node["children"],
-                        folder + os.sep + node["name"],
-                        bookmarks_list,
+                        bookmarks_json[node], folder, bookmarks_list
                     )
             return bookmarks_list
 
@@ -589,7 +596,5 @@ class ChromiumBasedBrowser(Browser, abc.ABC):
             bookmarks_list = []
             for root in b_m["roots"]:
                 if isinstance(b_m["roots"][root], dict):
-                    bookmarks_list = _deeper(
-                        b_m["roots"][root]["children"], root, bookmarks_list
-                    )
+                    bookmarks_list = _deeper(b_m["roots"][root], root, bookmarks_list)
         return bookmarks_list


### PR DESCRIPTION
# Description

Works for the `dump.json` provided in #107  .
Added check for subsequent dictionaries, which was not noticed in #67  

Fixes #107  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
