### PR TITLE
Add default browser support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,3 +2,4 @@
 good-names=
     i,
     e,
+ignored-modules=winreg

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ package to retrieve (almost) any browser's history on (almost) any platform.
  - **Bookmarks**: browser bookmarks with timestamp, URL, title and folder.
  - Lightweight: the entire package is less than 20kB in size and has no dependencies other than python 3.6+.
  - Developer friendly: you can add support for new browsers or add a new feature very easily.
+ - Default browser: can automatically determine the default browser on Windows and Linux (`browser-history -b default`).
  - Fully open source: this project is developed and maintained by [PES Open Source](https://github.com/pesos) and will always be open source (with the Apache 2.0 License).
 
 # Quick Start

--- a/browser_history/__init__.py
+++ b/browser_history/__init__.py
@@ -1,38 +1,7 @@
-import inspect
-import webbrowser
-
 from . import browsers, generic, utils  # noqa: F401
-
-if utils.get_platform() == utils.Platform.WINDOWS:
-    from winreg import HKEY_CURRENT_USER, OpenKey, QueryValueEx  # type: ignore
 
 
 __version__ = "0.3.0"
-
-
-def get_browsers():
-    """This method provides a list of all browsers implemented by
-    browser_history.
-
-    :return: A :py:class:`list` containing implemented browser classes
-        all inheriting from the super class
-        :py:class:`browser_history.generic.Browser`
-
-    :rtype: :py:class:`list`
-    """
-
-    # recursively get all concrete subclasses
-    def get_subclasses(browser):
-        # include browser itself in return list if it is concrete
-        sub_classes = []
-        if not inspect.isabstract(browser):
-            sub_classes.append(browser)
-
-        for sub_class in browser.__subclasses__():
-            sub_classes.extend(get_subclasses(sub_class))
-        return sub_classes
-
-    return get_subclasses(generic.Browser)
 
 
 def get_history():
@@ -46,7 +15,7 @@ def get_history():
     :rtype: :py:class:`browser_history.generic.Outputs`
     """
     output_object = generic.Outputs(fetch_type="history")
-    browser_classes = get_browsers()
+    browser_classes = utils.get_browsers()
     for browser_class in browser_classes:
         try:
             browser_object = browser_class()
@@ -69,7 +38,7 @@ def get_bookmarks():
     :rtype: :py:class:`browser_history.generic.Outputs`
     """
     output_object = generic.Outputs(fetch_type="bookmarks")
-    subclasses = get_browsers()
+    subclasses = utils.get_browsers()
     for browser_class in subclasses:
         try:
             browser_object = browser_class()
@@ -82,52 +51,3 @@ def get_bookmarks():
             utils.logger.info("%s", e)
     output_object.bookmarks.sort()
     return output_object
-
-
-def default_browser():
-    """This method gets the default browser of the current platform
-
-    :return: A :py:class:`browsers.Browser` object representing the default
-        browser in the current platform. If platform is not supported or
-        default browser is unknown or unsupported ``None`` is returned
-
-    :rtype: union[:py:class:`browsers.Browser`, None]
-    """
-    plat = utils.get_platform()
-
-    # ---- get default from specific platform ----
-
-    # Always try to return a lower-cased value for ease of comparison
-    if plat == utils.Platform.LINUX:
-        default = webbrowser.get().name.lower()
-    elif plat == utils.Platform.WINDOWS:
-        reg_path = (
-            "Software\\Microsoft\\Windows\\Shell\\Associations\\"
-            "UrlAssociations\\https\\UserChoice"
-        )
-        with OpenKey(HKEY_CURRENT_USER, reg_path) as key:
-            default = QueryValueEx(key, "ProgId")[0].lower()
-    else:
-        utils.logger.warning("Default browser feature not supported on this OS")
-        return None
-
-    # ---- convert obtained default to something we understand ----
-    all_browsers = get_browsers()
-
-    # first quick pass for direct matches
-    for browser in all_browsers:
-        if default == browser.name.lower() or default in browser.aliases:
-            return browser
-
-    # separate pass for deeper matches
-    for browser in all_browsers:
-        # look for alias matches even if the default name has "noise"
-        # for instance firefox on windows returns something like
-        # "firefoxurl-3EEDF34567DDE" but we only need "firefoxurl"
-        for alias in browser.aliases:
-            if alias in default:
-                return browser
-
-    # nothing was found
-    utils.logger.warning("Current default browser is not supported")
-    return None

--- a/browser_history/__init__.py
+++ b/browser_history/__init__.py
@@ -84,21 +84,6 @@ def get_bookmarks():
     return output_object
 
 
-# keep everything lower-cased
-browser_aliases = {
-    "google-chrome": browsers.Chrome,
-    "chromehtml": browsers.Chrome,
-    "chromiumhtm": browsers.Chromium,
-    "chromium-browser": browsers.Chromium,
-    "msedgehtm": browsers.Edge,
-    "operastable": browsers.Opera,
-    "opera-stable": browsers.Opera,
-    "operagxstable": browsers.OperaGX,
-    "firefoxurl": browsers.Firefox,
-    "bravehtml": browsers.Brave,
-}
-
-
 def default_browser():
     """This method gets the default browser of the current platform
 
@@ -112,6 +97,7 @@ def default_browser():
 
     # ---- get default from specific platform ----
 
+    # Always try to return a lower-cased value for ease of comparison
     if plat == utils.Platform.LINUX:
         default = webbrowser.get().name.lower()
     elif plat == utils.Platform.WINDOWS:
@@ -126,18 +112,21 @@ def default_browser():
         return None
 
     # ---- convert obtained default to something we understand ----
+    all_browsers = get_browsers()
 
-    b_map = {browser.__name__.lower(): browser for browser in get_browsers()}
-    if default in b_map:
-        # we are lucky and the name is exactly like we want it
-        return b_map[default]
+    # first quick pass for direct matches
+    for browser in all_browsers:
+        if default == browser.name.lower() or default in browser.aliases:
+            return browser
 
-    for browser in browser_aliases:
+    # separate pass for deeper matches
+    for browser in all_browsers:
         # look for alias matches even if the default name has "noise"
         # for instance firefox on windows returns something like
         # "firefoxurl-3EEDF34567DDE" but we only need "firefoxurl"
-        if browser in default:
-            return browser_aliases[browser]
+        for alias in browser.aliases:
+            if alias in default:
+                return browser
 
     # nothing was found
     utils.logger.warning("Current default browser is not supported")

--- a/browser_history/__init__.py
+++ b/browser_history/__init__.py
@@ -1,4 +1,6 @@
 import inspect
+import webbrowser
+
 from . import browsers, generic, utils  # noqa: F401
 
 
@@ -77,3 +79,33 @@ def get_bookmarks():
             utils.logger.info("%s", e)
     output_object.bookmarks.sort()
     return output_object
+
+
+# keep everything lower-cased
+browser_aliases = {
+    "google-chrome": "chrome",
+    "chromehtml": "chrome",
+    "chromium-browser": "chromium",
+    "msedgehtm": "edge",
+    "operastable": "opera",
+    "firefoxurl": "firefox",
+}
+
+
+def default_browser():
+    plat = utils.get_platform()
+
+    if plat == utils.Platform.LINUX:
+        default = webbrowser.get().name.lower()
+    else:
+        utils.logger.info("Default browser feature not supported on this OS")
+        return None
+
+    if default in [browser.__name__.lower() for browser in get_browsers()]:
+        # we are lucky and the name is exactly like we want it
+        return default
+    elif default in browser_aliases:
+        # check if it matches any aliases
+        return browser_aliases[default]
+    else:
+        utils.logger.info("Current default browser is not supported")

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -20,6 +20,7 @@ class Chromium(ChromiumBasedBrowser):
     """
 
     name = "Chromium"
+    aliases = ("chromiumhtm", "chromium-browser", "chromiumhtml")
 
     linux_path = ".config/chromium"
     windows_path = "AppData/Local/chromium/User Data"
@@ -40,6 +41,7 @@ class Chrome(ChromiumBasedBrowser):
     """
 
     name = "Chrome"
+    aliases = ("chromehtml", "google-chrome", "chromehtm")
 
     linux_path = ".config/google-chrome"
     windows_path = "AppData/Local/Google/Chrome/User Data"
@@ -61,6 +63,7 @@ class Firefox(Browser):
     """
 
     name = "Firefox"
+    aliases = ("firefoxurl", )
 
     linux_path = ".mozilla/firefox"
     windows_path = "AppData/Roaming/Mozilla/Firefox/Profiles"
@@ -177,6 +180,7 @@ class Edge(ChromiumBasedBrowser):
     """
 
     name = "Edge"
+    aliases = ("msedgehtm", "msedge")
 
     windows_path = "AppData/Local/Microsoft/Edge/User Data"
     mac_path = "Library/Application Support/Microsoft Edge"
@@ -195,6 +199,7 @@ class Opera(ChromiumBasedBrowser):
     """
 
     name = "Opera"
+    aliases = ("operastable", "opera-stable")
 
     linux_path = ".config/opera"
     windows_path = "AppData/Roaming/Opera Software/Opera Stable"
@@ -214,6 +219,7 @@ class OperaGX(ChromiumBasedBrowser):
     """
 
     name = "OperaGX"
+    aliases = ("operagxstable", "operagx-stable")
 
     windows_path = "AppData/Roaming/Opera Software/Opera GX Stable"
 
@@ -233,6 +239,7 @@ class Brave(ChromiumBasedBrowser):
     """
 
     name = "Brave"
+    aliases = ("bravehtml", )
 
     linux_path = ".config/BraveSoftware/Brave-Browser"
     mac_path = "Library/Application Support/BraveSoftware/Brave-Browser"

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -260,6 +260,7 @@ class Vivaldi(ChromiumBasedBrowser):
     """
 
     name = "Vivaldi"
+    aliases = ("vivaldi-stable", "vivaldistable")
 
     linux_path = ".config/vivaldi"
     mac_path = "Library/Application Support/Vivaldi"

--- a/browser_history/browsers.py
+++ b/browser_history/browsers.py
@@ -180,7 +180,7 @@ class Edge(ChromiumBasedBrowser):
     """
 
     name = "Edge"
-    aliases = ("msedgehtm", "msedge")
+    aliases = ("msedgehtm", "msedge", "microsoft-edge")
 
     windows_path = "AppData/Local/Microsoft/Edge/User Data"
     mac_path = "Library/Application Support/Microsoft Edge"

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -6,17 +6,15 @@ import sys
 
 from browser_history import (
     browsers,
-    default_browser,
     generic,
     get_bookmarks,
-    get_browsers,
     get_history,
     utils,
     __version__,
 )
 
 # get list of all implemented browser by finding subclasses of generic.Browser
-AVAILABLE_BROWSERS = ", ".join(b.__name__ for b in get_browsers())
+AVAILABLE_BROWSERS = ", ".join(b.__name__ for b in utils.get_browsers())
 AVAILABLE_FORMATS = ", ".join(generic.Outputs(fetch_type=None).format_map.keys())
 AVAILABLE_TYPES = ", ".join(generic.Outputs(fetch_type=None).field_map.keys())
 
@@ -112,13 +110,13 @@ def cli(args):
             # gets browser class by name (string).
             selected_browser = args.browser
             if selected_browser == "default":
-                default = default_browser()
+                default = utils.default_browser()
                 if default is None:
                     sys.exit(1)
                 else:
                     selected_browser = default.__name__
             else:
-                for browser in get_browsers():
+                for browser in utils.get_browsers():
                     if browser.__name__.lower() == args.browser.lower():
                         selected_browser = browser.__name__
                         break

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -112,13 +112,16 @@ def cli(args):
             # gets browser class by name (string).
             selected_browser = args.browser
             if selected_browser == "default":
-                args.browser = default_browser()
-                if args.browser is None:
+                default = default_browser()
+                if default is None:
                     sys.exit(1)
-            for browser in get_browsers():
-                if browser.__name__.lower() == args.browser.lower():
-                    selected_browser = browser.__name__
-                    break
+                else:
+                    selected_browser = default.__name__
+            else:
+                for browser in get_browsers():
+                    if browser.__name__.lower() == args.browser.lower():
+                        selected_browser = browser.__name__
+                        break
             browser_class = getattr(browsers, selected_browser)
         except AttributeError:
             utils.logger.error(

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -6,6 +6,7 @@ import sys
 
 from browser_history import (
     browsers,
+    default_browser,
     generic,
     get_bookmarks,
     get_browsers,
@@ -52,7 +53,7 @@ def make_parser():
         default="all",
         help=f"""
                 browser to retrieve history or bookmarks from. Should be one
-                of all, {AVAILABLE_BROWSERS}.
+                of all, default, {AVAILABLE_BROWSERS}.
                 Default is all (gets history or bookmarks from all browsers).
                 """,
     )
@@ -110,6 +111,10 @@ def cli(args):
         try:
             # gets browser class by name (string).
             selected_browser = args.browser
+            if selected_browser == "default":
+                args.browser = default_browser()
+                if args.browser is None:
+                    sys.exit(1)
             for browser in get_browsers():
                 if browser.__name__.lower() == args.browser.lower():
                     selected_browser = browser.__name__

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -49,6 +49,7 @@ class Browser(abc.ABC):
     * :py:class:`profile_support`
     * :py:class:`profile_dir_prefixes`
     * :py:class:`_local_tz`
+    * :py:class:`aliases` :A tuple containing other names for the browser in lowercase
 
     :param plat: the current platform. A value of :py:class:`None` means the platform
        will be inferred from the system.
@@ -57,6 +58,7 @@ class Browser(abc.ABC):
 
     >>> class CustomBrowser(Browser):
     ...     name = 'custom browser'
+    ...     aliases = ('custom-browser', 'customhtm')
     ...     history_file = 'history_file'
     ...     history_SQL = \"\"\"
     ...         SELECT
@@ -92,6 +94,12 @@ class Browser(abc.ABC):
 
     history_dir: Path
     """History directory."""
+
+    """Gets possible names (lower-cased) used to refer to the browser type. 
+    Useful for making the browser detectable as a default browser which may be 
+    named in various forms on different platforms. Do not include :py:class:`name` 
+    in this list"""
+    aliases: tuple = ()
 
     @property
     @abc.abstractmethod

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -49,7 +49,7 @@ class Browser(abc.ABC):
     * :py:class:`profile_support`
     * :py:class:`profile_dir_prefixes`
     * :py:class:`_local_tz`
-    * :py:class:`aliases` :A tuple containing other names for the browser in lowercase
+    * :py:class:`aliases`: A tuple containing other names for the browser in lowercase
 
     :param plat: the current platform. A value of :py:class:`None` means the platform
        will be inferred from the system.
@@ -95,11 +95,11 @@ class Browser(abc.ABC):
     history_dir: Path
     """History directory."""
 
-    """Gets possible names (lower-cased) used to refer to the browser type. 
-    Useful for making the browser detectable as a default browser which may be 
-    named in various forms on different platforms. Do not include :py:class:`name` 
-    in this list"""
     aliases: tuple = ()
+    """Gets possible names (lower-cased) used to refer to the browser type.
+    Useful for making the browser detectable as a default browser which may be
+    named in various forms on different platforms. Do not include :py:class:`name`
+    in this list"""
 
     @property
     @abc.abstractmethod

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -3,8 +3,12 @@ Module defines Platform class enumerates the popular Operating Systems.
 
 """
 import enum
+import inspect
 import logging
 import platform
+import webbrowser
+
+from . import generic
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
@@ -48,3 +52,81 @@ def get_platform():
     if system == "Windows":
         return Platform.WINDOWS
     raise NotImplementedError(f"Platform {system} is not supported yet")
+
+
+if get_platform() == Platform.WINDOWS:
+    from winreg import HKEY_CURRENT_USER, OpenKey, QueryValueEx  # type: ignore
+
+
+def get_browsers():
+    """This method provides a list of all browsers implemented by
+    browser_history.
+
+    :return: A :py:class:`list` containing implemented browser classes
+        all inheriting from the super class
+        :py:class:`browser_history.generic.Browser`
+
+    :rtype: :py:class:`list`
+    """
+
+    # recursively get all concrete subclasses
+    def get_subclasses(browser):
+        # include browser itself in return list if it is concrete
+        sub_classes = []
+        if not inspect.isabstract(browser):
+            sub_classes.append(browser)
+
+        for sub_class in browser.__subclasses__():
+            sub_classes.extend(get_subclasses(sub_class))
+        return sub_classes
+
+    return get_subclasses(generic.Browser)
+
+
+def default_browser():
+    """This method gets the default browser of the current platform
+
+    :return: A :py:class:`browsers.Browser` object representing the default
+        browser in the current platform. If platform is not supported or
+        default browser is unknown or unsupported ``None`` is returned
+
+    :rtype: union[:py:class:`browsers.Browser`, None]
+    """
+    plat = get_platform()
+
+    # ---- get default from specific platform ----
+
+    # Always try to return a lower-cased value for ease of comparison
+    if plat == Platform.LINUX:
+        default = webbrowser.get().name.lower()
+    elif plat == Platform.WINDOWS:
+        reg_path = (
+            "Software\\Microsoft\\Windows\\Shell\\Associations\\"
+            "UrlAssociations\\https\\UserChoice"
+        )
+        with OpenKey(HKEY_CURRENT_USER, reg_path) as key:
+            default = QueryValueEx(key, "ProgId")[0].lower()
+    else:
+        logger.warning("Default browser feature not supported on this OS")
+        return None
+
+    # ---- convert obtained default to something we understand ----
+    all_browsers = get_browsers()
+
+    # first quick pass for direct matches
+    for browser in all_browsers:
+        if default == browser.name.lower() or default in browser.aliases:
+            return browser
+
+    # separate pass for deeper matches
+    for browser in all_browsers:
+        # look for alias matches even if the default name has "noise"
+        # for instance firefox on windows returns something like
+        # "firefoxurl-3EEDF34567DDE" but we only need "firefoxurl"
+        for alias in browser.aliases:
+            if alias in default:
+                return browser
+
+    # nothing was found
+    logger.warning("Current default browser is not supported")
+    return None

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -112,11 +112,11 @@ def _default_browser_win():
 def default_browser():
     """This method gets the default browser of the current platform
 
-    :return: A :py:class:`browsers.Browser` object representing the default
-        browser in the current platform. If platform is not supported or
+    :return: A :py:class:`browser_history.generic.Browser` object representing the
+        default browser in the current platform. If platform is not supported or
         default browser is unknown or unsupported ``None`` is returned
 
-    :rtype: union[:py:class:`browsers.Browser`, None]
+    :rtype: union[:py:class:`browser_history.generic.Browser`, None]
     """
     plat = get_platform()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+# content of pytest.ini
+[pytest]
+markers =
+    browser_name: browser name used in default browser tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from browser_history import get_browsers
+from browser_history.utils import get_browsers
 from browser_history.cli import cli, AVAILABLE_BROWSERS
 from .utils import (  # noqa: F401
     become_linux,

--- a/tests/test_default_browser.py
+++ b/tests/test_default_browser.py
@@ -1,0 +1,58 @@
+# noqa: F401, F811
+# pylint: disable=redefined-outer-name,unused-argument,unused-import
+
+import webbrowser
+
+import pytest
+
+from browser_history.utils import default_browser
+from browser_history import browsers
+
+from .utils import become_mac, become_linux  # noqa: F401
+
+
+class MockBrowser:
+    def __init__(self, name=None):
+        self.name = name
+
+
+@pytest.fixture
+def change_webbrowser_default(monkeypatch, request):
+    """Changes webbrowser.get() to return a specific named
+    browser. use @pytest.mark.browser_name(name) to set
+    browser name
+    """
+
+    marker = request.node.get_closest_marker("browser_name")
+
+    if marker is None:
+        browser_name = None
+    else:
+        browser_name = marker.args[0]
+
+    def mock_get():
+        return MockBrowser(name=browser_name)
+
+    monkeypatch.setattr(webbrowser, "get", mock_get)
+
+
+@pytest.mark.browser_name("firefox")
+def test_default_firefox(become_linux, change_webbrowser_default):  # noqa: F811
+    """Test that firefox set as default is recognised
+    correctly"""
+    assert default_browser() == browsers.Firefox
+
+
+@pytest.mark.browser_name("chromehtml")
+def test_default_chrome(become_linux, change_webbrowser_default):  # noqa: F811
+    """Test that Chrome set as default is recognised
+    correctly"""
+    assert default_browser() == browsers.Chrome
+
+
+@pytest.mark.browser_name("safari")
+def test_default_safari(become_mac, change_webbrowser_default):  # noqa: F811
+    """Test that Safari set as default in MacOS is NOT
+    recognised correctly since default browser in MacOS is not
+    supported."""
+    assert default_browser() is None

--- a/tests/test_default_browser.py
+++ b/tests/test_default_browser.py
@@ -5,13 +5,20 @@ import webbrowser
 
 import pytest
 
-from browser_history.utils import default_browser
+from browser_history.utils import default_browser, get_platform, Platform
 from browser_history import browsers
 
-from .utils import become_mac, become_linux  # noqa: F401
+from .utils import become_mac, become_linux, become_windows  # noqa: F401
+
+
+platform = get_platform()
+if platform == Platform.WINDOWS:
+    import winreg
 
 
 class MockBrowser:
+    """Mock version of return value of webbrowser.get()"""
+
     def __init__(self, name=None):
         self.name = name
 
@@ -36,6 +43,28 @@ def change_webbrowser_default(monkeypatch, request):
     monkeypatch.setattr(webbrowser, "get", mock_get)
 
 
+@pytest.fixture
+def change_reg_browser_default(monkeypatch, request):
+    """Changes webbrowser.get() to return a specific named
+    browser. use @pytest.mark.browser_name(name) to set
+    browser name
+    """
+    if platform != Platform.WINDOWS:
+        pytest.skip("Skipping windows registry based test")
+
+    marker = request.node.get_closest_marker("browser_name")
+
+    if marker is None:
+        browser_name = None
+    else:
+        browser_name = marker.args[0]
+
+    def mock_QueryValueEx(key1, key2):
+        return [browser_name] if browser_name is not None else None
+
+    monkeypatch.setattr(winreg, "QueryValueEx", mock_QueryValueEx)
+
+
 @pytest.mark.browser_name("firefox")
 def test_default_firefox(become_linux, change_webbrowser_default):  # noqa: F811
     """Test that firefox set as default is recognised
@@ -50,9 +79,35 @@ def test_default_chrome(become_linux, change_webbrowser_default):  # noqa: F811
     assert default_browser() == browsers.Chrome
 
 
+def test_default_none(become_linux, change_webbrowser_default):  # noqa: F811
+    """Test that no default set returns None"""
+    assert default_browser() is None
+
+
 @pytest.mark.browser_name("safari")
 def test_default_safari(become_mac, change_webbrowser_default):  # noqa: F811
     """Test that Safari set as default in MacOS is NOT
     recognised correctly since default browser in MacOS is not
     supported."""
+    assert default_browser() is None
+
+
+@pytest.mark.browser_name("chromehtml")
+def test_default_windows_chrome(
+    become_windows, change_reg_browser_default  # noqa: F811
+):
+    """Test that chrome is identified correctly on Windows"""
+    assert default_browser() == browsers.Chrome
+
+
+@pytest.mark.browser_name("firefoxurl")
+def test_default_windows_firefox(
+    become_windows, change_reg_browser_default  # noqa: F811
+):
+    """Test that firefox is identified correctly on Windows"""
+    assert default_browser() == browsers.Firefox
+
+
+def test_default_windows_none(become_windows, change_reg_browser_default):  # noqa: F811
+    """Test that registry returning None is handled correctly"""
     assert default_browser() is None

--- a/tests/test_default_browser.py
+++ b/tests/test_default_browser.py
@@ -5,15 +5,12 @@ import webbrowser
 
 import pytest
 
-from browser_history.utils import default_browser, get_platform, Platform
-from browser_history import browsers
+from browser_history import browsers, utils
 
 from .utils import become_mac, become_linux, become_windows  # noqa: F401
 
 
-platform = get_platform()
-if platform == Platform.WINDOWS:
-    import winreg
+platform = utils.get_platform()
 
 
 class MockBrowser:
@@ -24,8 +21,8 @@ class MockBrowser:
 
 
 @pytest.fixture
-def change_webbrowser_default(monkeypatch, request):
-    """Changes webbrowser.get() to return a specific named
+def change_linux_default(monkeypatch, request):
+    """Changes utils._default_browser_linux to return a specific named
     browser. use @pytest.mark.browser_name(name) to set
     browser name
     """
@@ -38,18 +35,18 @@ def change_webbrowser_default(monkeypatch, request):
         browser_name = marker.args[0]
 
     def mock_get():
-        return MockBrowser(name=browser_name)
+        return browser_name
 
-    monkeypatch.setattr(webbrowser, "get", mock_get)
+    monkeypatch.setattr(utils, "_default_browser_linux", mock_get)
 
 
 @pytest.fixture
-def change_reg_browser_default(monkeypatch, request):
-    """Changes webbrowser.get() to return a specific named
+def change_win_default(monkeypatch, request):
+    """Changes utils._default_browser_win to return a specific named
     browser. use @pytest.mark.browser_name(name) to set
     browser name
     """
-    if platform != Platform.WINDOWS:
+    if platform != utils.Platform.WINDOWS:
         pytest.skip("Skipping windows registry based test")
 
     marker = request.node.get_closest_marker("browser_name")
@@ -59,55 +56,55 @@ def change_reg_browser_default(monkeypatch, request):
     else:
         browser_name = marker.args[0]
 
-    def mock_QueryValueEx(key1, key2):
-        return [browser_name] if browser_name is not None else None
+    def mock_get():
+        return browser_name
 
-    monkeypatch.setattr(winreg, "QueryValueEx", mock_QueryValueEx)
+    monkeypatch.setattr(utils, "_default_browser_win", mock_get)
 
 
 @pytest.mark.browser_name("firefox")
-def test_default_firefox(become_linux, change_webbrowser_default):  # noqa: F811
+def test_default_firefox(become_linux, change_linux_default):  # noqa: F811
     """Test that firefox set as default is recognised
     correctly"""
-    assert default_browser() == browsers.Firefox
+    assert utils.default_browser() == browsers.Firefox
 
 
 @pytest.mark.browser_name("chromehtml")
-def test_default_chrome(become_linux, change_webbrowser_default):  # noqa: F811
+def test_default_chrome(become_linux, change_linux_default):  # noqa: F811
     """Test that Chrome set as default is recognised
     correctly"""
-    assert default_browser() == browsers.Chrome
+    assert utils.default_browser() == browsers.Chrome
 
 
-def test_default_none(become_linux, change_webbrowser_default):  # noqa: F811
+def test_default_none(become_linux, change_linux_default):  # noqa: F811
     """Test that no default set returns None"""
-    assert default_browser() is None
+    assert utils.default_browser() is None
 
 
 @pytest.mark.browser_name("safari")
-def test_default_safari(become_mac, change_webbrowser_default):  # noqa: F811
+def test_default_safari(become_mac, change_linux_default):  # noqa: F811
     """Test that Safari set as default in MacOS is NOT
     recognised correctly since default browser in MacOS is not
     supported."""
-    assert default_browser() is None
+    assert utils.default_browser() is None
 
 
 @pytest.mark.browser_name("chromehtml")
 def test_default_windows_chrome(
-    become_windows, change_reg_browser_default  # noqa: F811
+    become_windows, change_win_default  # noqa: F811
 ):
     """Test that chrome is identified correctly on Windows"""
-    assert default_browser() == browsers.Chrome
+    assert utils.default_browser() == browsers.Chrome
 
 
 @pytest.mark.browser_name("firefoxurl")
 def test_default_windows_firefox(
-    become_windows, change_reg_browser_default  # noqa: F811
+    become_windows, change_win_default  # noqa: F811
 ):
     """Test that firefox is identified correctly on Windows"""
-    assert default_browser() == browsers.Firefox
+    assert utils.default_browser() == browsers.Firefox
 
 
-def test_default_windows_none(become_windows, change_reg_browser_default):  # noqa: F811
+def test_default_windows_none(become_windows, change_win_default):  # noqa: F811
     """Test that registry returning None is handled correctly"""
-    assert default_browser() is None
+    assert utils.default_browser() is None


### PR DESCRIPTION
# Description

This PR adds support for fetching history and bookmarks from default browsers.

## Default browser support Tracking

|  | Linux | Mac | Windows |
|--|---------|-------|--------------|
|Chrome | ✔️     | 🔲  |✔️  |
|firefox | ✔️     |🔲   |✔️ |
|Chromium | ✔️   | 🔲  | ✔️   |
|Edge | ✔️    |🔲  | ✔️  |
|Brave | 🔲    | 🔲   |✔️  |
|Opera | ✔️    | 🔲   |✔️  |
|OperaGX | 🔲    | 🔲   | ✔️  |
|Safari| ➖    | 🔲   | ➖   |
|Vivaldi|  ✔️         |  🔲        |   🔲     |

Fixes #96


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
