### PR TITLE
[FEATURE REQ] Add profile options in cli

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -113,7 +113,7 @@ def cli(args):
     args = parser.parse_args(args)
     if args.show_profiles:
         if args.show_profiles == "all":
-            utils.logger.error(
+            utils.logger.critical(
                 "'all' cannot be used with --show-profiles"
                 ", please specify a single browser"
             )
@@ -122,7 +122,7 @@ def cli(args):
         if browser_class is None:
             sys.exit(1)
         if not browser_class.profile_support:
-            utils.logger.error(
+            utils.logger.critical(
                 "%s browser does not support profiles", browser_class.name
             )
             sys.exit(1)
@@ -137,7 +137,7 @@ def cli(args):
     }
 
     if args.type not in fetch_map:
-        utils.logger.error(
+        utils.logger.critical(
             "Type %s is unavailable." " Check --help for available types", args.type
         )
         sys.exit(1)
@@ -160,7 +160,9 @@ def cli(args):
         profile = args.profile
         if profile is not None:
             if not browser_class.profile_support:
-                utils.logger.error("%s browser does not support profiles", browser.name)
+                utils.logger.critical(
+                    "%s browser does not support profiles", browser.name
+                )
                 sys.exit(1)
 
             # get the actual path from profile name
@@ -172,7 +174,7 @@ def cli(args):
             if not profile.exists():
                 # entire profile might be nonexistent or the specific history
                 # or bookmark file might be missing
-                utils.logger.error(
+                utils.logger.critical(
                     "Profile '%s' not found in %s browser "
                     "or profile does not contain %s",
                     args.profile,

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -90,7 +90,7 @@ def make_parser():
         metavar="BROWSER",
         help=f"""
                 List all available profiles for a given browser where browser
-                can be on of all, default, {AVAILABLE_BROWSERS}. The browser
+                can be one of default, {AVAILABLE_BROWSERS}. The browser
                 must always be provided.
         """,
     )
@@ -112,7 +112,15 @@ def cli(args):
     """
     args = parser.parse_args(args)
     if args.show_profiles:
+        if args.show_profiles == "all":
+            utils.logger.error(
+                "'all' cannot be used with --show-profiles"
+                ", please specify a single browser"
+            )
+            sys.exit(1)
         browser_class = utils.get_browser(args.show_profiles)
+        if browser_class is None:
+            sys.exit(1)
         if not browser_class.profile_support:
             utils.logger.error(
                 "%s browser does not support profiles", browser_class.name
@@ -134,14 +142,14 @@ def cli(args):
         )
         sys.exit(1)
 
-    if args.browser == "all":
+    if args.browser == "all" and args.profile is not None:
         # profiles are supported only for one browser at a time
-        if args.profile is not None:
-            utils.logger.error(
-                "Cannot use --profile option without specifying a browser"
-                " or with --browser set to 'all'"
-            )
-            sys.exit(1)
+        parser.error(
+            "Cannot use --profile option without specifying a browser"
+            " or with --browser set to 'all'"
+        )
+
+    if args.browser == "all":
         outputs = fetch_map[args.type]()
     else:
         browser_class = utils.get_browser(args.browser)

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -5,7 +5,6 @@ import argparse
 import sys
 
 from browser_history import (
-    browsers,
     generic,
     get_bookmarks,
     get_history,
@@ -76,6 +75,27 @@ def make_parser():
     )
 
     parser_.add_argument(
+        "-p",
+        "--profile",
+        default=None,
+        help="""
+                Specify the profile from which to fetch history or bookmarks. If
+                not provided all profiles are fetched
+        """,
+    )
+
+    parser_.add_argument(
+        "--show-profiles",
+        default=None,
+        metavar="BROWSER",
+        help=f"""
+                List all available profiles for a given browser where browser
+                can be on of all, default, {AVAILABLE_BROWSERS}. The browser
+                must always be provided.
+        """,
+    )
+
+    parser_.add_argument(
         "-v", "--version", action="version", version="%(prog)s " + __version__
     )
 
@@ -91,6 +111,17 @@ def cli(args):
     It parses arguments from sys.argv and performs the appropriate actions.
     """
     args = parser.parse_args(args)
+    if args.show_profiles:
+        browser_class = utils.get_browser(args.show_profiles)
+        if not browser_class.profile_support:
+            utils.logger.error(
+                "%s browser does not support profiles", browser_class.name
+            )
+            sys.exit(1)
+        for profile in browser_class().profiles(browser_class.history_file):
+            print(profile)
+        # ignore all other options and exit
+        sys.exit(0)
     outputs = None
     fetch_map = {
         "history": get_history,
@@ -104,34 +135,51 @@ def cli(args):
         sys.exit(1)
 
     if args.browser == "all":
-        outputs = fetch_map[args.type]()
-    else:
-        try:
-            # gets browser class by name (string).
-            selected_browser = args.browser
-            if selected_browser == "default":
-                default = utils.default_browser()
-                if default is None:
-                    sys.exit(1)
-                else:
-                    selected_browser = default.__name__
-            else:
-                for browser in utils.get_browsers():
-                    if browser.__name__.lower() == args.browser.lower():
-                        selected_browser = browser.__name__
-                        break
-            browser_class = getattr(browsers, selected_browser)
-        except AttributeError:
+        # profiles are supported only for one browser at a time
+        if args.profile is not None:
             utils.logger.error(
-                "Browser %s is unavailable." " Check --help for available browsers",
-                args.browser,
+                "Cannot use --profile option without specifying a browser"
+                " or with --browser set to 'all'"
             )
             sys.exit(1)
+        outputs = fetch_map[args.type]()
+    else:
+        browser_class = utils.get_browser(args.browser)
+        if browser_class is None:
+            sys.exit(1)
+
+        browser = browser_class()
+        profile = args.profile
+        if profile is not None:
+            if not browser_class.profile_support:
+                utils.logger.error("%s browser does not support profiles", browser.name)
+                sys.exit(1)
+
+            # get the actual path from profile name
+            if args.type == "history":
+                profile = browser.history_path_profile(profile)
+            elif args.type == "bookmarks":
+                profile = browser.bookmarks_path_profile(profile)
+
+            if not profile.exists():
+                # entire profile might be nonexistent or the specific history
+                # or bookmark file might be missing
+                utils.logger.error(
+                    "Profile '%s' not found in %s browser "
+                    "or profile does not contain %s",
+                    args.profile,
+                    browser.name,
+                    args.type,
+                )
+                sys.exit(1)
+            else:
+                # fetch_history and fetch_bookmarks require an array
+                profile = [profile]
 
         if args.type == "history":
-            outputs = browser_class().fetch_history()
+            outputs = browser.fetch_history(profile)
         elif args.type == "bookmarks":
-            outputs = browser_class().fetch_bookmarks()
+            outputs = browser.fetch_bookmarks(profile)
 
     try:
         if args.output is None:

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -193,6 +193,21 @@ class Browser(abc.ABC):
             return None
         return self.history_dir / profile_dir / self.history_file
 
+    def bookmarks_path_profile(self, profile_dir: Path) -> typing.Optional[Path]:
+        """Returns path of the bookmark file for the given ``profile_dir``
+
+        The ``profile_dir`` should be one of the outputs from
+        :py:meth:`profiles`
+
+        :param profile_dir: Profile directory (should be a single name,
+            relative to ``history_dir``)
+        :type profile_dir: :py:class:`pathlib.Path`
+        :return: path to bookmark file of the profile
+        """
+        if self.bookmarks_file is None:
+            return None
+        return self.history_dir / profile_dir / self.bookmarks_file
+
     def paths(self, profile_file):
         """Returns a list of file paths, for all profiles.
 

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -166,7 +166,7 @@ def get_browser(browser_name):
         or ``default`` (to fetch the default browser).
 
     :return: A browser class which is a subclass of
-        :py:class:`browser_history.generic.Browser` or ``None`` of no supported
+        :py:class:`browser_history.generic.Browser` or ``None`` if no supported
         browsers match the browser name given
 
     :rtype: union[:py:class:`browser_history.generic.Browser`, None]

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -10,7 +10,7 @@ import subprocess
 
 from . import generic
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("browser-history")
 handler = logging.StreamHandler()
 formatter = logging.Formatter("%(levelname)s: %(message)s")
 handler.setFormatter(formatter)

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -156,3 +156,33 @@ def default_browser():
     # nothing was found
     logger.warning("Current default browser is not supported")
     return None
+
+
+def get_browser(browser_name):
+    """
+    This method returns the browser class from a browser name.
+
+    :param browser_name: a string representing one of the browsers supported
+        or ``default`` (to fetch the default browser).
+
+    :return: A browser class which is a subclass of
+        :py:class:`browser_history.generic.Browser` or ``None`` of no supported
+        browsers match the browser name given
+
+    :rtype: union[:py:class:`browser_history.generic.Browser`, None]
+    """
+    # gets browser class by name (string).
+    if browser_name == "default":
+        return default_browser()
+    else:
+        browser_class = None
+        for browser in get_browsers():
+            if browser.__name__.lower() == browser_name.lower():
+                browser_class = browser
+                break
+        if browser_class is None:
+            logger.error(
+                "%s browser is unavailable. Check --help for available browsers",
+                browser_name,
+            )
+        return browser_class

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import csv
 import itertools
 import json
 import tempfile
+import re
 
 import pytest
 
@@ -69,7 +70,7 @@ GENERAL_INVALID_ARGS = [
 
 # Output markers:
 HELP_SIGNATURE = (
-    "usage: browser-history " "[-h] [-t TYPE] [-b BROWSER] [-f FORMAT] [-o OUTPUT]"
+    "usage: browser-history [-h] [-t TYPE] [-b BROWSER] [-f FORMAT] [-o OUTPUT]"
 )
 HISTORY_HEADER = "Timestamp,URL"
 BOOKMARKS_HEADER = "Timestamp,URL,Title,Folder"
@@ -307,3 +308,191 @@ def test_invalid_browser(change_homedir):  # noqa: F811
         with pytest.raises(SystemExit) as e:
             cli(["-b", bad_browser])
             assert e.value.code == 1
+
+
+def test_chrome_linux_profiles(capsys, become_linux, change_homedir):  # noqa: F811
+    """Test --show-profiles option for Chrome on linux"""
+    out = None
+    try:
+        cli(["--show-profiles", "chrome"])
+    except SystemExit:
+        captured = capsys.readouterr()
+        out = captured.out
+
+    assert out.strip() == "Profile"
+
+
+def test_chromium_linux_profiles(capsys, become_linux, change_homedir):  # noqa: F811
+    """Test --show-profiles option for Chromium on linux"""
+    out = None
+    try:
+        cli(["--show-profiles", "chromium"])
+    except SystemExit:
+        captured = capsys.readouterr()
+        out = captured.out
+    # use set to make the comparison order-insensitive
+    profiles = set(out.strip().split("\n"))
+    assert profiles == {"Default", "Profile"}
+
+
+def test_firefox_windows_profiles(capsys, become_windows, change_homedir):  # noqa: F811
+    """Test --show-profiles option for Firefox on Windows"""
+    out = None
+    try:
+        cli(["--show-profiles", "firefox"])
+    except SystemExit:
+        captured = capsys.readouterr()
+        out = captured.out
+
+    assert out.strip() == "Profile 1\nProfile 2"
+
+
+def test_safari_mac_profiles(caplog, become_mac, change_homedir):  # noqa: F811
+    """Test --show-profiles option for Safari on Mac
+
+    This test checks for failure with a error code 1
+    """
+    try:
+        cli(["--show-profiles", "safari"])
+    except SystemExit as e:
+        assert e.code == 1
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert record.levelname == "CRITICAL"
+        assert record.message == "Safari browser does not support profiles"
+
+
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+def test_show_profiles_all(caplog, platform):  # noqa: F811
+    """Test --show-profile option with "all" parameter which should fail with
+    error code 1.
+    """
+    try:
+        cli(["--show-profiles", "all"])
+    except SystemExit as e:
+        assert e.code == 1
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert record.levelname == "CRITICAL"
+        assert (
+            record.message == "'all' cannot be used with --show-profiles, "
+            "please specify a single browser"
+        )
+
+
+@pytest.mark.parametrize("browser_arg", INVALID_BROWSER_ARGS)
+def test_show_profiles_invalid(caplog, browser_arg):  # noqa: F811
+    """Test --show-profile option with "all" parameter which should fail with
+    error code 1.
+    """
+    try:
+        cli(["--show-profiles", browser_arg])
+    except SystemExit as e:
+        assert e.code == 1
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert record.levelname == "ERROR"
+        assert record.message.endswith(
+            "browser is unavailable. Check --help for available browsers"
+        )
+
+
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+@pytest.mark.parametrize("profile_arg", ("-p", "--profile"))
+def test_profile_all(capsys, platform, profile_arg):  # noqa: F811
+    """Test -p/--profile option with "all" option on all platforms.
+
+    Since the "all" option is not valid, the test checks for exit failure
+    """
+    try:
+        cli([profile_arg, "all"])
+    except SystemExit as e:
+        assert e.code == 2
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    print(err)
+    assert err.strip().endswith(
+        "Cannot use --profile option without specifying"
+        " a browser or with --browser set to 'all'"
+    )
+
+
+@pytest.mark.parametrize("profile_arg", ("-p", "--profile"))
+def test_profile_safari(caplog, become_mac, profile_arg):  # noqa: F811
+    """Test -p/--profile option with Safari on all platforms.
+
+    Since Safari does not support profiles, the test checks for failure
+    """
+    try:
+        cli(["-b", "safari", profile_arg, "some_profile"])
+    except SystemExit as e:
+        assert e.code == 1
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert record.levelname == "CRITICAL"
+        assert record.message == "Safari browser does not support profiles"
+
+
+@pytest.mark.parametrize("platform", all_platform_fixtures, indirect=True)
+@pytest.mark.parametrize("profile_arg", ("-p", "--profile"))
+@pytest.mark.parametrize("profile_name", ("nonexistent", "nonexistent2", "some-prof"))
+@pytest.mark.parametrize("browser", ("firefox", "chrome"))
+def test_profile_nonexistent(
+    caplog, platform, profile_arg, profile_name, browser
+):  # noqa: F811
+    """Test -p/--profile option with a nonexistent profile"""
+    try:
+        cli(["-b", browser, profile_arg, profile_name])
+    except SystemExit as e:
+        assert e.code == 1
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert record.levelname == "CRITICAL"
+        assert re.match(
+            r"Profile '.*' not found in .* browser or profile does not contain history",
+            record.message,
+        )
+
+
+def test_firefox_windows_profile(capsys, become_windows, change_homedir):  # noqa: F811
+    """Test -p/--profile for Firefox on Windows"""
+    cli(["-b", "firefox", "-p", "Profile 2"])
+
+    out, err = capsys.readouterr()
+    assert out.startswith("Timestamp,URL")
+    assert out.endswith("https://www.reddit.com/\r\n\n")
+    assert err == ""
+
+
+def test_firefox_windows_profile_bookmarks(
+    capsys, become_windows, change_homedir  # noqa: F81
+):
+    """Test -p/--profile for Firefox on Windows, for bookmarks"""
+    cli(["-b", "firefox", "-p", "Profile 1", "-t", "bookmarks"])
+
+    out, err = capsys.readouterr()
+    assert out.startswith("Timestamp,URL,Title,Folder")
+    assert err == ""
+
+
+@pytest.mark.parametrize("type_arg", ("nonexistent", "cookies", "invalid"))
+def test_firefox_windows_profile_invalid_type(caplog, type_arg):  # noqa: F811
+    """Test -p/--profile option with a nonexistent profile"""
+    try:
+        cli(["-b", "firefox", "-p", "Profile 1", "-t", type_arg])
+    except SystemExit as e:
+        assert e.code == 1
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert record.levelname == "CRITICAL"
+        assert re.match(
+            r"Type .* is unavailable. Check --help for available types",
+            record.message,
+        )

--- a/tests/test_default_browser.py
+++ b/tests/test_default_browser.py
@@ -1,8 +1,6 @@
 # noqa: F401, F811
 # pylint: disable=redefined-outer-name,unused-argument,unused-import
 
-import webbrowser
-
 import pytest
 
 from browser_history import browsers, utils
@@ -90,17 +88,13 @@ def test_default_safari(become_mac, change_linux_default):  # noqa: F811
 
 
 @pytest.mark.browser_name("chromehtml")
-def test_default_windows_chrome(
-    become_windows, change_win_default  # noqa: F811
-):
+def test_default_windows_chrome(become_windows, change_win_default):  # noqa: F811
     """Test that chrome is identified correctly on Windows"""
     assert utils.default_browser() == browsers.Chrome
 
 
-@pytest.mark.browser_name("firefoxurl")
-def test_default_windows_firefox(
-    become_windows, change_win_default  # noqa: F811
-):
+@pytest.mark.browser_name("firefoxurl-3EEDF34567DDE")
+def test_default_windows_firefox(become_windows, change_win_default):  # noqa: F811
     """Test that firefox is identified correctly on Windows"""
     assert utils.default_browser() == browsers.Firefox
 


### PR DESCRIPTION
# Description

This PR adds cli functionality allowing `--show-profiles` to display all available profiles for a browser and `-p/--profiles` to specify which profile to use when fetching history and bookmarks.
Along with these are the addition of 
1. `get_browser` method in `utils.py` which provides a cleaner way of getting the browser class from the strings provided in the 
CLI. 
2. `bookmark_path_profile` in `generic.py` which provides a way to get the path to a bookmark file in a given profile.

Fixes #74 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
