### PR TITLE
[DOCS] add "Usage" section detailing all usecases with examples

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ or platform, please open an issue on `the GitHub Page <https://github.com/pesos/
    :caption: Contents:
 
    quickstart
+   usage
    cli
    browsers
    API

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,142 @@
+.. _usage:
+
+
+*****
+Usage
+*****
+
+This section details all the uses of ``browser-history`` with complete code examples for each.
+Refer the :ref:`quick_start` for basic usage.
+
+Using the API
+=============
+
+``browser-history`` has an `API <https://en.wikipedia.org/wiki/API#Libraries_and_frameworks>`_
+that allows you to extract history and bookmarks through python code, perhaps in other python programs.
+
+.. _history-usage:
+
+History
+-------
+
+The main use case of ``browser-history`` is to extract browsing history from various browsers installed on the system.
+
+History from all browsers
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To get consolidated history from all browsers:
+::
+
+    from browser_history import get_history
+
+    outputs = get_history()
+
+    # his is a list of (datetime.datetime, url) tuples
+    his = outputs.histories
+
+History from the default browser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+    Experimental feature. This only works on Linux and Windows, but not for every browser. (see `this PR <https://github.com/pesos/browser-history/pull/123>`_ to check browser and platform support)
+
+Let ``browser-history`` automatically detect the default browser set in the system:
+::
+
+    from browser_history.utils import default_browser
+
+    BrowserClass = default_browser()
+
+    if BrowserClass is None:
+        # default browser could not be identified
+        print("could not get default browser!")
+    else:
+        b = BrowserClass()
+        # his is a list of (datetime.datetime, url) tuples
+        his = b.fetch_history().histories
+
+History from a specific browser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you need histories from a specific browser:
+::
+
+    from browser_history.browsers import Firefox
+
+    f = Firefox()
+    outputs = f.fetch_history()
+
+    # his is a list of (datetime.datetime, url) tuples
+    his = outputs.histories
+
+``Firefox`` in the above snippet can be replaced with any of the :ref:`supported_browsers`.
+
+
+History from a specific profile of a browser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``browser-history`` can also extract history from one particular profile of a browser. The profile directory is usually quite different across different systems, this workflow is better suited for the command line tool.
+
+Example:
+::
+
+    from browser_history.browsers import Firefox
+
+    b = Firefox()
+
+    # this gives a list of all available profile names
+    profiles_available = b.profiles(b.history_file)
+
+    # use the history_profiles function to get histories
+    # it needs a list of profile names to use
+    outputs = b.history_profiles([profiles_available[0]])
+
+    his = outputs.histories
+
+
+Save histories to a file
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``outputs.save("filename.ext")`` to save histories to a file (``outputs`` is obtained from ``fetch_history`` as shown in the previous examples). ``ext`` should be one of the supported extensions (``csv``, ``json``, ``jsonl``, etc.). See :py:meth:`~browser_history.generic.Outputs.save` for the list of all supported extensions.
+
+Example:
+::
+
+    from browser_history import get_history
+
+    outputs = get_history()
+
+    # save as CSV
+    outputs.save("history.csv")
+    # save as JSON
+    outputs.save("history.json")
+    # override format
+    outputs.save("history_file", output_format="json")
+
+
+
+Bookmarks
+---------
+
+.. warning::
+    Experimental feature. Although this has been confirmed to work on multiple (Firefox and Chromium based) browsers
+    on all platforms, it is not covered by tests and has not been used as much as the history feature.
+
+``browser-history`` also supports extracting bookmarks from some browsers.
+
+All of the usage is similar to extracting history (including saving to a file). You can use the same code examples from :ref:`history-usage` with the following changes:
+
+#. Replace ``fetch_history`` with ``fetch_bookmarks`` (and ``get_history`` with ``get_bookmarks``)
+
+#. Replace ``outputs.histories`` with ``outputs.bookmarks``
+
+Bookmarks (from ``outputs.bookmarks``) are a list of ``(datetime.datetime, url, title, folder)`` tuples.
+
+Using the CLI
+=============
+
+``browser-history`` provides a command-line interface that can be accessed by typing ``browser-history`` in a terminal (in Windows, this will be the CMD command prompt or powershell).
+
+The CLI provides all of the functionality of ``browser-history`` (please `open an issue <https://github.com/pesos/browser-history/issues>`_ if any feature is missing from the CLI).
+
+More information about the CLI here: :ref:`cli`.


### PR DESCRIPTION
# Description

I noticed that there were no clear examples which showed everything that can be done with `browser-history`. Adding these to the quickstart would make it no longer be a "quick" start. So, I added a new section/chapter in the documentation that shows "what" you can do with `browser-history` along with "how" to do the thing that you need.

I got a little lazy with the Bookmarks section, since the code is pretty much the same except for the words being replaced.

Some examples for the CLI would also be useful (perhaps a future issue/PR).

## Type of change

- [ ] Documentation

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
