### PR TITLE
[CODE] Return None if requested browser is not supported on current platform

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -328,6 +328,20 @@ class Browser(abc.ABC):
                 output_object.bookmarks.sort(reverse=desc)
         return output_object
 
+    @classmethod
+    def is_supported(cls):
+        """Checks whether the browser is supported on current platform
+
+        :return: True if browser is supported on current platform else False
+        :rtype: boolean
+        """
+        support_check = {
+            utils.Platform.LINUX: cls.linux_path,
+            utils.Platform.WINDOWS: cls.windows_path,
+            utils.Platform.MAC: cls.mac_path
+        }
+        return support_check.get(utils.get_platform()) is not None
+
 
 class Outputs:
     """

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -179,12 +179,7 @@ def get_browser(browser_name):
         browser_class = None
         for browser in get_browsers():
             if browser.__name__.lower() == browser_name.lower():
-                support_check = {
-                    Platform.LINUX: browser.linux_path,
-                    Platform.WINDOWS: browser.windows_path,
-                    Platform.MAC: browser.mac_path
-                }
-                if support_check.get(get_platform()) is not None:
+                if browser.is_supported():
                     browser_class = browser
                 break
         if browser_class is None:

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -166,8 +166,9 @@ def get_browser(browser_name):
         or ``default`` (to fetch the default browser).
 
     :return: A browser class which is a subclass of
-        :py:class:`browser_history.generic.Browser` or ``None`` if no supported
-        browsers match the browser name given
+        :py:class:`browser_history.generic.Browser` otherwise ``None`` if no
+        supported browsers match the browser name given or the given browser
+        is not supported on the current platform
 
     :rtype: union[:py:class:`browser_history.generic.Browser`, None]
     """
@@ -178,7 +179,13 @@ def get_browser(browser_name):
         browser_class = None
         for browser in get_browsers():
             if browser.__name__.lower() == browser_name.lower():
-                browser_class = browser
+                support_check = {
+                    Platform.LINUX: browser.linux_path,
+                    Platform.WINDOWS: browser.windows_path,
+                    Platform.MAC: browser.mac_path
+                }
+                if support_check.get(get_platform()) is not None:
+                    browser_class = browser
                 break
         if browser_class is None:
             logger.error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-from browser_history.utils import get_browsers
+from browser_history.utils import get_browsers, get_browser
 from browser_history.cli import cli, AVAILABLE_BROWSERS
 from .utils import (  # noqa: F401
     become_linux,
@@ -136,6 +136,11 @@ def test_browser_argument(browser_arg, capsys, platform):
     """Test arguments for the browser option."""
     for browser_opt in VALID_CMD_OPTS[2]:
         try:
+            if get_browser(browser_arg) is None:
+                # if browser is in VALID_BROWSER_ARG but not supported on
+                # current platform it will throw a SystemExit so lets raise
+                # an AssertionError and handle it like the rest
+                raise AssertionError("browser is unavailable")
             cli([browser_opt, browser_arg])
             captured = capsys.readouterr()
             assert CSV_HISTORY_HEADER in captured.out
@@ -145,6 +150,7 @@ def test_browser_argument(browser_arg, capsys, platform):
                 for browser_unavailable_err in (
                     "browser is not supported",
                     "browser is not installed",
+                    "browser is unavailable"
                 )
             ):
                 # In case the tester does not have access to the browser
@@ -217,6 +223,11 @@ def test_argument_combinations(capsys, platform, browser):
     for index_a, index_b in itertools.product(indices, indices):
         if available_browser:
             try:
+                if get_browser(browser) is None:
+                    # if browser is in AVAILABLE_BROWSERS but not supported on
+                    # current platform it will throw a SystemExit so lets raise
+                    # an AssertionError and handle it like the rest
+                    raise AssertionError("browser is unavailable")
                 cli(
                     [
                         VALID_CMD_OPTS[1][index_a],  # type
@@ -232,6 +243,7 @@ def test_argument_combinations(capsys, platform, browser):
                         "browser is not supported",
                         "browser is not installed",
                         "Bookmarks are not supported",
+                        "browser is unavailable"
                     )
                 ):
                     # In case the tester does not have access to the browser


### PR DESCRIPTION
# Description

This commit makes get_browser return None for browsers not supported on current platform. This ensures you will not try to instantiate an unsupported browser and get an `AssertionError` or `NotImplementedError`. This useful in reducing unnecessary clutter in the CLI and other internal code.

Fixes #124 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
