### PR TITLE
Fix Safari/Firefox bug in pipenv on macOS

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -265,7 +265,8 @@ class Browser(abc.ABC):
         with tempfile.TemporaryDirectory() as tmpdirname:
             for history_path in history_paths:
                 copied_history_path = shutil.copy2(history_path.absolute(), tmpdirname)
-                conn = sqlite3.connect(f"file:{copied_history_path}?mode=ro", uri=True)
+                conn = sqlite3.connect(
+                    f"file:{copied_history_path}?mode=ro&immutable=1&nolock=1", uri=True)
                 cursor = conn.cursor()
                 cursor.execute(self.history_SQL)
                 date_histories = [

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -265,7 +265,9 @@ class Browser(abc.ABC):
         with tempfile.TemporaryDirectory() as tmpdirname:
             for history_path in history_paths:
                 copied_history_path = shutil.copy2(history_path.absolute(), tmpdirname)
-                conn = sqlite3.connect(f"file:{copied_history_path}?mode=ro", uri=True)
+                conn = sqlite3.connect(
+                    f"file:{copied_history_path}?mode=ro&immutable=1&nolock=1", uri=True
+                )
                 cursor = conn.cursor()
                 cursor.execute(self.history_SQL)
                 date_histories = [
@@ -338,7 +340,7 @@ class Browser(abc.ABC):
         support_check = {
             utils.Platform.LINUX: cls.linux_path,
             utils.Platform.WINDOWS: cls.windows_path,
-            utils.Platform.MAC: cls.mac_path
+            utils.Platform.MAC: cls.mac_path,
         }
         return support_check.get(utils.get_platform()) is not None
 

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -265,8 +265,7 @@ class Browser(abc.ABC):
         with tempfile.TemporaryDirectory() as tmpdirname:
             for history_path in history_paths:
                 copied_history_path = shutil.copy2(history_path.absolute(), tmpdirname)
-                conn = sqlite3.connect(
-                    f"file:{copied_history_path}?mode=ro&immutable=1&nolock=1", uri=True)
+                conn = sqlite3.connect(f"file:{copied_history_path}?mode=ro", uri=True)
                 cursor = conn.cursor()
                 cursor.execute(self.history_SQL)
                 date_histories = [


### PR DESCRIPTION
fixes #139

# Description

As discussed in the issue, this seems to fix problems when working with pipenv on macOS with pyenv-installed Python 3.8.9 and below.

To test:
1. Install pyenv and pipenv
2. create pipenv with Python 3.8.9: `pipenv install --python=3.8.9`
3. clone PR and run `pipenv install -e .` to install PR version
4. run `browser-history -b Firefox`

Fixes #139

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [y] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [y ] I have performed a self-review of my own code (if applicable)

- [ depends] My changes generate no new warnings 

Pytest fails on windows and linux tests, but I guess that's expected on macOS

- [ y] I have enabled the pre-commit hook and it's not detecting any issue.
- [ y] Any dependent and pending changes have been merged and published


P.S.: Contributor instructions are missing to install `python-dateutil` to run the tests successfully.