### PR TITLE
[CLI][TESTS] Fix error message when browser is unsupported and add tests for platform utils

### DIFF
--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -129,7 +129,7 @@ class Browser(abc.ABC):
         homedir = Path.home()
 
         error_string = (
-            self.name + f" browser is not supported on {utils.get_platform_name(plat)}"
+            f"{self.name} browser is not supported on {utils.get_platform_name(plat)}"
         )
         if plat == utils.Platform.WINDOWS:
             assert self.windows_path is not None, error_string

--- a/browser_history/generic.py
+++ b/browser_history/generic.py
@@ -128,15 +128,17 @@ class Browser(abc.ABC):
             plat = utils.get_platform()
         homedir = Path.home()
 
-        error_string = self.name + " browser is not supported on {}"
+        error_string = (
+            self.name + f" browser is not supported on {utils.get_platform_name(plat)}"
+        )
         if plat == utils.Platform.WINDOWS:
-            assert self.windows_path is not None, error_string.format("windows")
+            assert self.windows_path is not None, error_string
             self.history_dir = homedir / self.windows_path
         elif plat == utils.Platform.MAC:
-            assert self.mac_path is not None, error_string.format("Mac OS")
+            assert self.mac_path is not None, error_string
             self.history_dir = homedir / self.mac_path
         elif plat == utils.Platform.LINUX:
-            assert self.linux_path is not None, error_string.format("Linux")
+            assert self.linux_path is not None, error_string
             self.history_dir = homedir / self.linux_path
         else:
             raise NotImplementedError()

--- a/browser_history/utils.py
+++ b/browser_history/utils.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import platform
 import subprocess
+from typing import Optional
 
 from . import generic
 
@@ -52,6 +53,20 @@ def get_platform():
     if system == "Windows":
         return Platform.WINDOWS
     raise NotImplementedError(f"Platform {system} is not supported yet")
+
+
+def get_platform_name(plat: Optional[Platform] = None) -> str:
+    """Returns human readable name of the current platform"""
+    if plat is None:
+        plat = get_platform()
+
+    if plat == Platform.LINUX:
+        return "Linux"
+    if plat == Platform.WINDOWS:
+        return "Windows"
+    if plat == Platform.MAC:
+        return "MacOS"
+    return "Unknown"
 
 
 def get_browsers():
@@ -181,10 +196,19 @@ def get_browser(browser_name):
             if browser.__name__.lower() == browser_name.lower():
                 if browser.is_supported():
                     browser_class = browser
-                break
+                    break
+                else:
+                    logger.error(
+                        "%s browser is not supported on %s",
+                        browser_name,
+                        get_platform_name(),
+                    )
+                    return
+
         if browser_class is None:
             logger.error(
                 "%s browser is unavailable. Check --help for available browsers",
                 browser_name,
             )
+
         return browser_class

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+from browser_history.utils import get_platform, get_platform_name, Platform
+from .utils import become_linux, become_mac, become_windows  # noqa: F401
+
+
+def test_plat_linux(become_linux):  # noqa: F811
+    assert get_platform() == Platform.LINUX
+
+
+def test_plat_mac(become_mac):  # noqa: F811
+    assert get_platform() == Platform.MAC
+
+
+def test_plat_win(become_windows):  # noqa: F811
+    assert get_platform() == Platform.WINDOWS
+
+
+def test_platform_name_linux(become_linux):  # noqa: F811
+    assert get_platform_name() == "Linux"
+
+
+def test_platform_name_mac(become_mac):  # noqa: F811
+    assert get_platform_name() == "MacOS"
+
+
+def test_platform_name_win(become_windows):  # noqa: F811
+    assert get_platform_name() == "Windows"


### PR DESCRIPTION
# Description

 - The error message when browser is unsupported on the current platform said `ERROR: <name> browser is unavailable. Check --help for available browsers`. The help section listed this as a valid browser name. This can cause confusion as the reason is that the browser is not supported on current platform.
 - Added a new function `get_platform_name` in `utils` that returns a human readable name of the current platform.
 - Added rudimentary tests for `get_platform` and `get_platform_name`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
