### PR TITLE
Adding ASCII art in CLI

### DIFF
--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -3,7 +3,7 @@ command line interface of browser-history."""
 
 import argparse
 import sys
-from argparse import RawTextHelpFormatter
+from argparse import RawDescriptionHelpFormatter
 
 from browser_history import (
     generic,
@@ -42,7 +42,7 @@ def make_parser():
                 Checkout the GitHub repo
                 https://github.com/pesos/browser-history
                 if you have any issues or want to help contribute""",
-        formatter_class=RawTextHelpFormatter,
+        formatter_class=RawDescriptionHelpFormatter,
     )
 
     parser_.add_argument(

--- a/browser_history/cli.py
+++ b/browser_history/cli.py
@@ -3,6 +3,7 @@ command line interface of browser-history."""
 
 import argparse
 import sys
+from argparse import RawTextHelpFormatter
 
 from browser_history import (
     generic,
@@ -28,11 +29,20 @@ def make_parser():
     parser_ = argparse.ArgumentParser(
         description="""
                     A tool to retrieve history from
-                    (almost) any browser on (almost) any platform""",
+                    (almost) any browser on (almost) any platform
+
+██████╗ ██████╗  ██████╗ ██╗    ██╗███████╗███████╗██████╗       ██╗  ██╗██╗███████╗████████╗ ██████╗ ██████╗ ██╗   ██╗
+██╔══██╗██╔══██╗██╔═══██╗██║    ██║██╔════╝██╔════╝██╔══██╗      ██║  ██║██║██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗╚██╗ ██╔╝
+██████╔╝██████╔╝██║   ██║██║ █╗ ██║███████╗█████╗  ██████╔╝█████╗███████║██║███████╗   ██║   ██║   ██║██████╔╝ ╚████╔╝
+██╔══██╗██╔══██╗██║   ██║██║███╗██║╚════██║██╔══╝  ██╔══██╗╚════╝██╔══██║██║╚════██║   ██║   ██║   ██║██╔══██╗  ╚██╔╝
+██████╔╝██║  ██║╚██████╔╝╚███╔███╔╝███████║███████╗██║  ██║      ██║  ██║██║███████║   ██║   ╚██████╔╝██║  ██║   ██║
+╚═════╝ ╚═╝  ╚═╝ ╚═════╝  ╚══╝╚══╝ ╚══════╝╚══════╝╚═╝  ╚═╝      ╚═╝  ╚═╝╚═╝╚══════╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝   ╚═╝
+                    """,  # noqa: E501
         epilog="""
                 Checkout the GitHub repo
                 https://github.com/pesos/browser-history
                 if you have any issues or want to help contribute""",
+        formatter_class=RawTextHelpFormatter,
     )
 
     parser_.add_argument(


### PR DESCRIPTION
# Description

In this commit, I have added ASCII art in the cli.py, whenever `browser-history -h` will be used for run, It will show an ASCII art stating the BROWSER-HISTORY.

Fixes #162 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
