### PR TITLE
[CODE] Use a setup.cfg instead of multiple config files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-source=./browser_history
-branch=true
-

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = A001, E203, P101, P103, W503

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,0 @@
-[BASIC]
-good-names=
-    i,
-    e,
-ignored-modules=winreg

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-# content of pytest.ini
-[pytest]
-markers =
-    browser_name: browser name used in default browser tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,55 @@
+[metadata]
+name = browser-history
+version = attr: browser_history.__version__
+description = A python module to extract browser history
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/pesos/browser-history
+author = Samyak Sarnayak
+author_email = samyak201@gmail.com
+license = Apache License 2.0
+license_files = LICENSE
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+project_urls =
+    Documentation = https://github.com/pesos/browser-history/docs
+    Source = https://github.com/pesos/browser-history/
+    Tracker = https://github.com/pesos/browser-history/
+
+[options]
+include_package_data = true
+packages = find:
+python_requires = >=3.6
+zip_safe = false
+
+[options.packages.find]
+exclude =
+    tests
+
+[options.entry_points]
+console_scripts =
+    browser-history = browser_history.cli:main
+
+[bdist_wheel]
+universal = true
+
+[run]
+source=./browser_history
+branch=true
+
+[flake8]
+max-line-length = 88
+extend-ignore = A001, E203, P101, P103, W503
+
+[tool:pytest]
+testpaths = tests
+markers =
+    browser_name: browser name used in default browser tests
+python_files = *test_*.py
+
+[pylint]
+ignored-modules=winreg
+[pylint.basic]
+good-names=i,e

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,15 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 project_urls =
-    Documentation = https://github.com/pesos/browser-history/docs
+    Documentation = https://browser-history.readthedocs.io/en/stable/
     Source = https://github.com/pesos/browser-history/
-    Tracker = https://github.com/pesos/browser-history/
+    Tracker = https://github.com/pesos/browser-history/issues
 
 [options]
 include_package_data = true
 packages = find:
 python_requires = >=3.6
-zip_safe = false
+zip_safe = true
 
 [options.packages.find]
 exclude =
@@ -35,7 +35,7 @@ console_scripts =
 [bdist_wheel]
 universal = true
 
-[run]
+[coverage:run]
 source=./browser_history
 branch=true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,6 @@ exclude =
 console_scripts =
     browser-history = browser_history.cli:main
 
-[bdist_wheel]
-universal = true
-
 [coverage:run]
 source=./browser_history
 branch=true

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ browser-history is a simple, zero-dependencies, developer-friendly
 python package to retrieve (almost) any browser's history on (almost)
 any platform.
 
-See https://browser-history.readthedocs.io/en/latest/browsers.html for
-more help.
+See https://browser-history.readthedocs.io/en/stable/ for more help.
 """
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,32 @@
-import setuptools
+"""
+browser-history's setup.
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+browser-history is a simple, zero-dependencies, developer-friendly
+python package to retrieve (almost) any browser's history on (almost)
+any platform.
 
-setuptools.setup(
-    name="browser-history",  # Replace with your own username
-    version="0.3.1",
-    author="Samyak Sarnayak",
-    author_email="samyak201@gmail.com",
-    description="A python module to extract browser history",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/pesos/browser-history",
-    packages=setuptools.find_packages(exclude=["tests"]),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires=">=3.6",
-    entry_points={
-        "console_scripts": ["browser-history=browser_history.cli:main"],
-    },
-)
+See https://browser-history.readthedocs.io/en/latest/browsers.html for
+more help.
+"""
+
+try:
+    import setuptools
+except ImportError:
+    raise RuntimeError(
+        "Could not install browser-history in the environment as setuptools "
+        "is missing. Please create a new virtual environment before proceeding"
+    )
+
+import platform
+
+MIN_PYTHON_VERSION = ("3", "6")
+
+if platform.python_version_tuple() < MIN_PYTHON_VERSION:
+    raise SystemExit(
+        "Could not install browser-history in the environment. The"
+        " browser-history package requires python version 3.6+, you are using "
+        f"{platform.python_version()}"
+    )
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
# Description
Friday, September 24, 2021 - v0.3.1

## Added:
- Support for a unified setup.cfg file which hosts all the configuration settings for the project.
- Updated the metadata within the config file to match the setup.py &  adopt a more declarative style of python project configuration.

## Removed:
- Deprecated `.coveragerc`, `.flake8`, `.pylintrc` and `pytest.ini` files.

# Checklist:

- [x] I have read the [contribution guidelines](https://browser-history.readthedocs.io/en/latest/contributing.html) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] My changes generate no new warnings 
- [x] I have enabled the pre-commit hook and it's not detecting any issue.
- [x] Any dependent and pending changes have been merged and published
